### PR TITLE
[Backend]Add AppStream translations

### DIFF
--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -5,7 +5,7 @@ from . import db, utils
 
 
 def load_appstream():
-    apps = utils.appstream2dict("repo")
+    apps, apps_locale = utils.appstream2dict("repo")
 
     current_apps = {app[5:] for app in db.redis_conn.smembers("apps:index")}
     current_categories = db.redis_conn.smembers("categories:index")
@@ -46,6 +46,10 @@ def load_appstream():
                 for category in categories:
                     p.sadd("categories:index", category)
                     p.sadd(f"categories:{category}", redis_key)
+
+            for key, value in apps_locale.items():
+                if appid in value:
+                    p.set(f"apps_locale:{key}.{appid}", json.dumps(value[appid]))
 
         for appid in current_apps - set(apps):
             p.delete(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -122,9 +122,15 @@ def list_appstream():
 
 
 @app.get("/appstream/{appid}", status_code=200)
-def get_appstream(appid: str, response: Response):
+def get_appstream(appid: str, response: Response, lang: str = None):
     if value := db.get_json_key(f"apps:{appid}"):
-        return value
+        if lang:
+            if translation := db.get_json_key(f"apps_locale:{lang}.{appid}"):
+                return value | translation
+            else:
+                return value
+        else:
+            return value
 
     response.status_code = 404
     return None

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -40,7 +40,7 @@ def add_translation(apps_locale: dict, language: str, appid: str, key: str, valu
     apps_locale[language][appid][key] = value
 
 
-def appstream2dict(reponame: str, language: str = None):
+def appstream2dict(reponame: str):
     if config.settings.appstream_repos is not None:
         appstream_path = os.path.join(
             config.settings.appstream_repos,


### PR DESCRIPTION
This adds Support for AppStream translations. To use this, call /appstream/appid with the new lang parameter e.g. appstream/org.gimp.GIMP?lang=de. You will get the translated AppStream. This PR is currently WIP. Some fields are missing in the translation. I want to hear some opinions before going further.