### PR TITLE
Add domain name tests and allow subdomains

### DIFF
--- a/backend/app/verification.py
+++ b/backend/app/verification.py
@@ -134,6 +134,11 @@ def _get_domain_name(app_id: str) -> str | None:
         projectname = _demangle_name(projectname)
         # https://sourceforge.net/p/forge/documentation/Project%20Web%20Services/
         return f"{projectname}.{domain}.io".lower()
+    elif len(app_id.split(".")) == 4:
+        [tld, domain, subdomain] = app_id.split(".")[0:3]
+        subdomain = _demangle_name(subdomain)
+        domain = _demangle_name(domain)
+        return f"{subdomain}.{domain}.{tld}".lower()
     else:
         [tld, domain] = app_id.split(".")[0:2]
         domain = _demangle_name(domain)

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -465,6 +465,9 @@ def test_verification_domain_names():
         _get_domain_name("net.sourceforge._0example.App") == "0example.sourceforge.io"
     )
 
+    # Subdomain
+    assert _get_domain_name("io.frama.tractor.carburetor") == "tractor.frama.io"
+
     # Normal top-level domain
     assert _get_domain_name("org.flathub.TestApp") == "flathub.org"
     assert _get_domain_name("org._0example.TestApp") == "0example.org"


### PR DESCRIPTION
We might not want this and there could be a security argument made for not enabling it.

Reported via https://discourse.flathub.org/t/verification-for-apps-hosted-on-framagit/5683