### PR TITLE
Prevent post login from erroring, by changing call order

### DIFF
--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -821,11 +821,13 @@ def continue_oauth_flow(
             )
         db.session.add(account)
     request.session["user-id"] = account.user
+
+    # The session is now ready
+    db.session.commit()
+
     # Let's find the set of repos the user has write access to in the flathub
     # org since we have a functional token
     postlogin_handler(login_result, account)
-    # The session is now ready
-    db.session.commit()
 
     worker.send_email.send(
         EmailInfo(


### PR DESCRIPTION
When first creating your account, we first need to commit to the database, to have a valid `account` object, that we can use in postlogin.

So far only github has postlogin in useage, I've checked both cases to work without error now.