### PR TITLE
Fix Lightbox error with non existent index

### DIFF
--- a/frontend/src/components/application/CarouselStrip.tsx
+++ b/frontend/src/components/application/CarouselStrip.tsx
@@ -33,6 +33,7 @@ export const CarouselStrip = ({
 
   useEffect(() => {
     setCurrentScreenshot(0)
+    setCurrentIndex(0)
   }, [app.id])
 
   const lightboxState = ref.current?.getLightboxState()
@@ -85,7 +86,7 @@ export const CarouselStrip = ({
             controller={{ ref }}
             plugins={[Inline]}
             slides={slides}
-            index={currentScreenshot}
+            index={slides?.length > currentScreenshot ? currentScreenshot : 0}
             carousel={{
               finite: slides?.length === 1,
             }}


### PR DESCRIPTION
When change current index to second slide, and jump to another app with only one image, an exception was launched.

This PR fix this problem, by preventing a non existent index.

Fixes #2416 