### PR TITLE
Allow transliterate names for non-Latin scripts.

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -74,7 +74,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
       <ThemeProvider attribute="class">
         <DefaultSeo
           dangerouslySetAllPagesToNoIndex={!IS_PRODUCTION}
-          titleTemplate="%s | Flathub"
+          titleTemplate="%s | {t('Flathub')}"
           defaultTitle={t("flathub-apps-for-linux")}
           description={t("flathub-description")}
           languageAlternates={languages

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -74,7 +74,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
       <ThemeProvider attribute="class">
         <DefaultSeo
           dangerouslySetAllPagesToNoIndex={!IS_PRODUCTION}
-          titleTemplate="%s | {t('Flathub')}"
+          titleTemplate={`%s | ${t("Flathub")}`}
           defaultTitle={t("flathub-apps-for-linux")}
           description={t("flathub-description")}
           languageAlternates={languages

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -74,7 +74,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
       <ThemeProvider attribute="class">
         <DefaultSeo
           dangerouslySetAllPagesToNoIndex={!IS_PRODUCTION}
-          titleTemplate={`%s | ${t("Flathub")}`}
+          titleTemplate={`%s | ${t("flathub")}`}
           defaultTitle={t("flathub-apps-for-linux")}
           description={t("flathub-description")}
           languageAlternates={languages

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,4 +1,6 @@
 {
+  "flathub": "Flathub",
+  "flathub-logo": "Flathub Logo",
   "more-pages": "More pages",
   "carousel": "Carousel",
   "slide": "Slide",

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -121,7 +121,7 @@ const Footer = () => {
 
         <div>
           <div className="flex justify-center text-2xl font-bold sm:block sm:text-base pb-3">
-            {t("Flathub")}
+            {t("flathub")}
           </div>
           <div className="flex flex-col sm:space-y-3">
             <Link

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -78,7 +78,7 @@ const Footer = () => {
               target="_blank"
               rel="noreferrer me"
             >
-              Mastodon
+              {t("Mastodon")}
             </a>
           </div>
         </div>
@@ -121,7 +121,7 @@ const Footer = () => {
 
         <div>
           <div className="flex justify-center text-2xl font-bold sm:block sm:text-base pb-3">
-            Flathub
+            {t("Flathub")}
           </div>
           <div className="flex flex-col sm:space-y-3">
             <Link

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -78,7 +78,7 @@ const Footer = () => {
               target="_blank"
               rel="noreferrer me"
             >
-              {t("Mastodon")}
+              Mastodon
             </a>
           </div>
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -223,7 +223,7 @@ const Header = () => {
                 <div className="flex md:absolute md:inset-y-0 md:start-0 lg:static xl:col-span-4">
                   <div className="flex h-full w-full flex-shrink-0 items-center">
                     <OrganizationJsonLd
-                      name="Flathub"
+                      name={t("flathub")}
                       url={`${process.env.NEXT_PUBLIC_SITE_BASE_URI}`}
                       logo={logoEmail.src}
                       sameAs={[
@@ -243,7 +243,7 @@ const Header = () => {
                         <div className="hidden lg:block">
                           <Image
                             src={logoToolbarSvg}
-                            alt="Flathub Logo"
+                            alt={t("flathub-logo")}
                             width={88}
                             height={24}
                             priority
@@ -252,7 +252,7 @@ const Header = () => {
                         <div className="block lg:hidden">
                           <Image
                             src={logoMini}
-                            alt="Flathub Logo"
+                            alt={t("flathub-logo")}
                             width={24}
                             height={22}
                             style={{ width: 24, height: 22 }}


### PR DESCRIPTION
In locales with non-Latin script, the names should be transliterated to be readable.