### PR TITLE
utils: Handle no component type in catalogue data

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -74,7 +74,7 @@ def appstream2dict(appstream_url=None) -> dict[str, dict]:
     for component in root:
         app = {}
 
-        app["type"] = component.attrib.get("type")
+        app["type"] = component.attrib.get("type", "generic")
 
         descriptions = component.findall("description")
         if len(descriptions):


### PR DESCRIPTION
Typeless component in catalogue data is allowed and there is no difference between typeless and an explicit
type="generic" https://github.com/ximion/appstream/issues/609#issuecomment-1962977993

So assume generic when no type is present.

A typeless metainfo file can be supplied by baseapps, extensions or runtimes on Flathub as they don't go through the linter. The rest are blocked from doing so by the linter. 


So hopefully nothing that matters, should explode under this assumption.