### PR TITLE
Always register vending api

### DIFF
--- a/backend/app/vending/__init__.py
+++ b/backend/app/vending/__init__.py
@@ -723,21 +723,7 @@ def register_to_app(app: FastAPI):
     This is reliant on session and DB middlewares, and the login support being registered.
     """
 
-    # Refuse to load if stripe configuration unavailable
-
-    if any(
-        blank
-        in [
-            settings.stripe_secret_key,
-            settings.stripe_public_key,
-            settings.stripe_webhook_key,
-        ]
-        for blank in [None, ""]
-    ):
-        print("Stripe configuration is missing, refusing to add vending APIs")
-        return
-    else:
-        stripe.api_key = settings.stripe_secret_key
+    stripe.api_key = settings.stripe_secret_key
 
     app.include_router(router)
     app.add_exception_handler(VendingError, vendingerror_exception_handler)


### PR DESCRIPTION
Before this we needed to always set the stipe variables when we wanted to run codegen for the frontend, which was very annoying. This always registers the api, but stipe will likly fail, when running - which should be fine for testing.

This behavior also fooled local development, as developer portal management pages were not accessible due to these apis missing completly.