### PR TITLE
Add feed endpoints that mirror the old ones but use postgres

### DIFF
--- a/backend/app/compat.py
+++ b/backend/app/compat.py
@@ -88,6 +88,22 @@ def get_recently_added():
     return [app for app in compat if app]
 
 
+@router.get("/apps/collection/recently-updated-postgres", tags=["compat"])
+@router.get("/apps/collection/recently-updated-postgres/50", tags=["compat"])
+def get_recently_updated_postgres():
+    recent = apps.get_recently_updated_postgres(50)
+    compat = [get_short_app(f"apps:{app_id}") for app_id in recent]
+    return [app for app in compat if app]
+
+
+@router.get("/apps/collection/new-postgres", tags=["compat"])
+@router.get("/apps/collection/new-postgres/50", tags=["compat"])
+def get_recently_added_postgres():
+    added = apps.get_recently_added_postgres(50)
+    compat = [get_short_app(f"apps:{app_id}") for app_id in added]
+    return [app for app in compat if app]
+
+
 @router.get("/apps/collection/popular", tags=["compat"])
 @router.get("/apps/collection/popular/50", tags=["compat"])
 def get_popular_apps():

--- a/backend/app/feed.py
+++ b/backend/app/feed.py
@@ -20,3 +20,18 @@ def get_recently_updated_apps_feed():
 @router.get("/new", tags=["feed"])
 def get_new_apps_feed():
     return Response(content=feeds.get_new_apps_feed(), media_type="application/rss+xml")
+
+
+@router.get("/recently-updated-postgres", tags=["feed"])
+def get_recently_updated_apps_feed_postgres():
+    return Response(
+        content=feeds.get_recently_updated_apps_feed_postgres(),
+        media_type="application/rss+xml",
+    )
+
+
+@router.get("/new-postgres", tags=["feed"])
+def get_new_apps_feed_postgres():
+    return Response(
+        content=feeds.get_new_apps_feed_postgres(), media_type="application/rss+xml"
+    )

--- a/backend/app/feeds.py
+++ b/backend/app/feeds.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
+from fastapi_sqlalchemy import db as sqldb
 from feedgen.feed import FeedGenerator
 
-from . import db
+from . import db, models
 
 
 def generate_feed(key: str, title: str, description: str, link: str):
@@ -36,9 +37,97 @@ def generate_feed(key: str, title: str, description: str, link: str):
         entry.link(href=f"https://flathub.org/apps/{app['id']}")
 
         timestamp = int(timestamp)
-        entry_date = datetime.utcfromtimestamp(timestamp).strftime(
-            "%a, %d %b %Y %H:%M:%S"
+        entry_date = datetime.fromtimestamp(timestamp).strftime("%a, %d %b %Y %H:%M:%S")
+        entry.pubDate(f"{entry_date} UTC")
+
+        content = [
+            '<img src="https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{}.png">'.format(
+                app["id"]
+            ),
+            f"<p>{app['summary']}</p>",
+        ]
+
+        if description := app.get("description"):
+            content.append(f"<p>{description}</p>")
+
+        content.append("<h3>Additional information:</h3>")
+        content.append("<ul>")
+
+        if developer_name := app.get("developer_name"):
+            content.append(f"<li>Developer: {developer_name}</li>")
+
+        if license := app.get("license"):
+            content.append(f"<li>License: {license}")
+
+        if app_releases := app.get("releases"):
+            release = app_releases[0] if len(app_releases) else None
+            if release:
+                content.append(f"<li>Version: {release['version']}")
+
+        content.append("</ul>")
+
+        if screenshots := app.get("screenshots"):
+            screenshots = screenshots[0:3]
+
+            for screenshot in screenshots:
+                if image := list(screenshot["sizes"].values())[0]:
+                    content.append(f'<img src="{image}">')
+
+        entry.description("".join(content))
+
+    return feed.rss_str()
+
+
+def generate_feed_postgres(mode: str, title: str, description: str, link: str):
+    feed = FeedGenerator()
+    feed.title(title)
+    feed.description(description)
+    feed.link(href=link)
+    feed.language("en")
+
+    if mode == "new":
+        appids = (
+            sqldb.session.query(models.Apps)
+            .order_by(models.Apps.initial_release_at.desc())
+            .limit(10)
+            .all()
         )
+        appids_for_frontend = [
+            tuple((app.app_id, app.initial_release_at))
+            for app in appids
+            if db.is_appid_for_frontend(app.app_id)
+        ]
+    else:
+        appids = (
+            sqldb.session.query(models.Apps)
+            .order_by(models.Apps.last_updated_at.desc())
+            .limit(10)
+            .all()
+        )
+        appids_for_frontend = [
+            tuple((app.app_id, app.last_updated_at))
+            for app in appids
+            if db.is_appid_for_frontend(app.app_id)
+        ]
+
+    apps = [
+        (db.get_json_key(f"apps:{appid[0]}"), appid[1]) for appid in appids_for_frontend
+    ]
+
+    for app, timestamp in reversed(apps):
+        # sanity check: if index includes an app, but apps:ID is null, skip it
+        if not app:
+            continue
+
+        # sanity check: if application doesn't have the name field, skip it
+        if not app.get("name"):
+            continue
+
+        entry = feed.add_entry()
+        entry.title(app["name"])
+        entry.link(href=f"https://flathub.org/apps/{app['id']}")
+
+        entry_date = timestamp.strftime("%a, %d %b %Y %H:%M:%S")
         entry.pubDate(f"{entry_date} UTC")
 
         content = [
@@ -91,6 +180,24 @@ def get_recently_updated_apps_feed():
 def get_new_apps_feed():
     return generate_feed(
         "new_apps_zset",
+        "Flathub – recently added applications",
+        "Applications recently published on Flathub",
+        "https://flathub.org/apps/collection/new",
+    )
+
+
+def get_recently_updated_apps_feed_postgres():
+    return generate_feed_postgres(
+        "recently_updated",
+        "Flathub – recently updated applications",
+        "Recently updated applications published on Flathub",
+        "https://flathub.org/apps/collection/recently-updated",
+    )
+
+
+def get_new_apps_feed_postgres():
+    return generate_feed_postgres(
+        "new_apps",
         "Flathub – recently added applications",
         "Applications recently published on Flathub",
         "https://flathub.org/apps/collection/new",

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -175,7 +175,7 @@ def parse_summary(summary, sqldb):
     return summary_dict, recently_updated_zset, metadata
 
 
-def update(sqldb):
+def update(sqldb) -> None:
     current_apps = {app[5:] for app in db.redis_conn.smembers("apps:index")}
 
     repo_file = Gio.File.new_for_path(f"{config.settings.flatpak_user_dir}/repo")
@@ -310,5 +310,3 @@ def update(sqldb):
                     reverse_lookup[ext] = app_id
 
     db.redis_conn.set("summary:reverse_lookup", json.dumps(reverse_lookup))
-
-    return len(recently_updated_zset)


### PR DESCRIPTION
These are experimental endpoints, so that we can validate them to be correct against the current ones and then replace the old ones with these.

Then we should be able to drop the `recently_updated_zset` and `new_apps_zset` from redis