### PR TITLE
Accept forwarded ips

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 alembic upgrade head
-uvicorn app.main:router --host 0.0.0.0 --port 8000 $@
+uvicorn app.main:router --host 0.0.0.0 --port 8000 --forwarded-allow-ips='*' $@


### PR DESCRIPTION
See https://www.uvicorn.org/deployment/#running-behind-nginx

Please have a look at this @barthalion 

This should allow us to get the correct IP address of a client in the python backend code

https://stackoverflow.com/a/70012569 mentions, that this should be locked down to the IP of the nginx for security reasons - but I'm unsure, if that's really a problem - but wouldn't hurt