### PR TITLE
Don't show verified count

### DIFF
--- a/frontend/pages/apps/collection/verified/[page].tsx
+++ b/frontend/pages/apps/collection/verified/[page].tsx
@@ -31,7 +31,6 @@ export default function Verified({
           applications={applications.hits.map(mapAppsIndexToAppstreamListItem)}
           page={applications.page}
           totalPages={applications.totalPages}
-          totalHits={applications.totalHits}
         />
       </div>
     </>


### PR DESCRIPTION
We're capped at 1000 due to meili defaulting to only return these