### PR TITLE
If we don't have a theme (yet) especially on server side, default to …

### DIFF
--- a/frontend/@/lib/helpers.ts
+++ b/frontend/@/lib/helpers.ts
@@ -59,7 +59,13 @@ export function chooseBrandingColor(
   }
 
   const brandingColor = branding.find((a) => {
-    return a.scheme_preference === (theme as "light" | "dark")
+    // if theme is undefined, default to dark
+    // this happens when rendering server side
+    if (theme) {
+      return a.scheme_preference === (theme as "light" | "dark")
+    } else {
+      return a.scheme_preference === "dark"
+    }
   })
 
   if (brandingColor) {


### PR DESCRIPTION
…the dark branding

We've choosen the dark one, as that shouldn't be flashing and going from the dark to the light one might not hurt your eyes.