### PR TITLE
fix issue #3259: App verification step has incorrect domain computation

### DIFF
--- a/backend/app/verification.py
+++ b/backend/app/verification.py
@@ -135,8 +135,14 @@ def _get_domain_name(app_id: str) -> str | None:
         # https://sourceforge.net/p/forge/documentation/Project%20Web%20Services/
         return f"{projectname}.{domain}.io".lower()
     else:
-        [tld, domain] = app_id.split(".")[0:2]
-        domain = _demangle_name(domain)
+        compons = app_id.split(".")
+        compons.pop(-1) # remove the app name
+
+        domain = _demangle_name(compons.pop(-1))
+
+        compons.reverse()
+        tld = ".".join(compons)
+
         return f"{domain}.{tld}".lower()
 
 


### PR DESCRIPTION
- I have not tested this locally; too much work to set up everything just for a couple of line; sorry.
- I'm not satisfied with this fix; it won't handle sites with `www` prefix; but I think that was already broken