### PR TITLE
i18n: localize Mastodon footer link

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -4,6 +4,7 @@
   "search-apps": "Search apps",
   "publish": "Publish",
   "forum": "Forum",
+  "mastodon": "Mastodon",
   "about": "About",
   "about-description": "Flathub is the place to get and distribute apps for Linux. It is powered by Flatpak which allows Flathub apps to run on almost any Linux distribution.",
   "about-pagename": "About Flathub: The Linux App Store",

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -78,7 +78,7 @@ const Footer = () => {
               target="_blank"
               rel="noreferrer me"
             >
-              Mastodon
+              {t("mastodon")}
             </a>
           </div>
         </div>


### PR DESCRIPTION
I don't see a problem with that, the name Mastodon is translated on there official website as well.