### PR TITLE
Add creation timestamp to email queue request

### DIFF
--- a/backend/app/emails.py
+++ b/backend/app/emails.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 from enum import Enum
 from typing import Any
 
@@ -170,6 +171,7 @@ def build_notification(
 
     payload = {
         "messageId": f"{request.build_repo}/{request.build_id}",
+        "creation_timestamp": datetime.datetime.now().timestamp(),
         "subject": subject,
         "previewText": subject,
         "messageInfo": {

--- a/backend/app/invites.py
+++ b/backend/app/invites.py
@@ -142,6 +142,7 @@ def invite_developer(
 
     payload = {
         "messageId": f"{app.app_id}/{invite.id}/invited",
+        "creation_timestamp": datetime.now().timestamp(),
         "userId": invited_user.id,
         "subject": subject,
         "previewText": subject,
@@ -198,6 +199,7 @@ def accept_invite(
 
     payload = {
         "messageId": f"{app_id}/{invite.id}/success",
+        "creation_timestamp": datetime.now().timestamp(),
         "subject": f"{username} is now a developer",
         "previewText": f"{username} is now a developer",
         "messageInfo": {
@@ -238,6 +240,7 @@ def decline_invite(
 
     payload = {
         "messageId": f"{app.app_id}/{invite.id}/decline",
+        "creation_timestamp": datetime.now().timestamp(),
         "subject": f"{login.user.display_name} declined their invite",
         "previewText": f"{login.user.display_name} declined their invite",
         "messageInfo": {
@@ -279,6 +282,7 @@ def leave_team(
 
     payload = {
         "messageId": f"{app_id}/{login.user.id}/{datetime.now().isoformat()}/left",
+        "creation_timestamp": datetime.now().timestamp(),
         "subject": f"{login.user.display_name} left the developer team",
         "previewText": f"{login.user.display_name} left the developer team",
         "messageInfo": {

--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -836,6 +836,7 @@ def continue_oauth_flow(
 
     payload = {
         "messageId": f"{account.user}/login/{datetime.now().isoformat()}",
+        "creation_timestamp": datetime.now().timestamp(),
         "userId": account.user,
         "subject": "New login to Flathub account",
         "previewText": "Flathub Login",

--- a/backend/app/moderation.py
+++ b/backend/app/moderation.py
@@ -141,9 +141,11 @@ def get_moderation_apps(
             ),
         )
         .filter(
-            models.ModerationRequest.handled_at.is_(None)
-            if show_handled is False
-            else models.ModerationRequest.handled_at.isnot(None),
+            (
+                models.ModerationRequest.handled_at.is_(None)
+                if show_handled is False
+                else models.ModerationRequest.handled_at.isnot(None)
+            ),
             models.ModerationRequest.is_outdated.is_(False),
         )
         .group_by(models.ModerationRequest.appid)
@@ -449,6 +451,7 @@ def submit_review_request(
 
                 payload = {
                     "messageId": f"{app_id}/{review_request.build_id}/held",
+                    "creation_timestamp": datetime.now().timestamp(),
                     "subject": f"Build #{review_request.build_id} held for review",
                     "previewText": f"Build #{review_request.build_id} held for review",
                     "inform_moderators": True,
@@ -556,6 +559,7 @@ def submit_review(
 
     payload = {
         "messageId": f"{request.appid}/{request.build_id}/{'approved' if request.is_approved else 'rejected'}",
+        "creation_timestamp": datetime.now().timestamp(),
         "subject": subject,
         "previewText": subject,
         "inform_moderators": True,

--- a/backend/app/upload_tokens.py
+++ b/backend/app/upload_tokens.py
@@ -190,6 +190,7 @@ def create_upload_token(
 
     payload = {
         "messageId": f"{app_id}/{token.id}/issued",
+        "creation_timestamp": datetime.datetime.now().timestamp(),
         "subject": "New upload token issued",
         "previewText": "New upload token issued",
         "messageInfo": {


### PR DESCRIPTION
This should never be used in the email itself, only use it to figure out, if a request has been stuck in the queue for very long times and consider dropping it.