### PR TITLE
Add chromatic token

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: chpt_683b948867f365a
           workingDir: ./frontend


### PR DESCRIPTION
Expose key for everyone, according to https://www.chromatic.com/docs/github-actions/#run-chromatic-on-external-forks-of-open-source-projects