### PR TITLE
Use png for icons again

### DIFF
--- a/backend/app/feeds.py
+++ b/backend/app/feeds.py
@@ -41,7 +41,7 @@ def generate_feed(key: str, title: str, description: str, link: str):
         entry.pubDate(f"{entry_date} UTC")
 
         content = [
-            '<img src="https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{}.webp">'.format(
+            '<img src="https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{}.png">'.format(
                 app["id"]
             ),
             f"<p>{app['summary']}</p>",
@@ -131,7 +131,7 @@ def generate_feed_postgres(mode: str, title: str, description: str, link: str):
         entry.pubDate(f"{entry_date} UTC")
 
         content = [
-            '<img src="https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{}.webp">'.format(
+            '<img src="https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{}.png">'.format(
                 app["id"]
             ),
             f"<p>{app['summary']}</p>",

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -242,11 +242,11 @@ def appstream2dict(appstream_url=None) -> tuple[dict[str, dict], dict[str, dict]
                 if icon_type == "remote":
                     if icon.text.startswith("https://dl.flathub.org/media/"):
                         if "icon" not in app:
-                            app["icon"] = re.sub(".png$", ".webp", icon.text)
+                            app["icon"] = icon.text
                         attrs = {}
                         for attr in icon.attrib:
                             attrs[attr] = icon.attrib[attr]
-                        attrs.update({"url": re.sub(".png$", ".webp", icon.text)})
+                        attrs.update({"url": icon.text})
                         iconListNewLocation.append(attrs)
 
             if not app.get("icon"):
@@ -255,7 +255,7 @@ def appstream2dict(appstream_url=None) -> tuple[dict[str, dict], dict[str, dict]
                     if icon_type == "cached":
                         if "icon" not in app:
                             app["icon"] = (
-                                f"https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{re.sub('.png$', '.webp', icon.text)}"
+                                f"https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/{icon.text}"
                             )
                         attrs = {}
                         for attr in icon.attrib:
@@ -263,7 +263,7 @@ def appstream2dict(appstream_url=None) -> tuple[dict[str, dict], dict[str, dict]
                         scaleSuffix = f"@{attrs['scale']}" if "scale" in attrs else ""
                         attrs.update(
                             {
-                                "url": f"https://dl.flathub.org/repo/appstream/x86_64/icons/{attrs['height']}x{attrs['width']}{scaleSuffix}/{re.sub('.png$', '.webp', icon.text)}"
+                                "url": f"https://dl.flathub.org/repo/appstream/x86_64/icons/{attrs['height']}x{attrs['width']}{scaleSuffix}/{icon.text}"
                             }
                         )
                         iconListOldLocation.append(attrs)

--- a/backend/tests/snapshots/main__apps_by_category__test_apps_by_category.json
+++ b/backend/tests/snapshots/main__apps_by_category__test_apps_by_category.json
@@ -10,7 +10,7 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
       "categories": [
         "Game"
       ],

--- a/backend/tests/snapshots/main__apps_by_category_locale__test_apps_by_category_locale.json
+++ b/backend/tests/snapshots/main__apps_by_category_locale__test_apps_by_category_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__apps_by_developer__test_apps_by_developer.json
+++ b/backend/tests/snapshots/main__apps_by_developer__test_apps_by_developer.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__apps_by_developer_locale__test_apps_by_developer_locale.json
+++ b/backend/tests/snapshots/main__apps_by_developer_locale__test_apps_by_developer_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__appstream_by_appid__test_appstream_by_appid.json
+++ b/backend/tests/snapshots/main__appstream_by_appid__test_appstream_by_appid.json
@@ -119,7 +119,7 @@
     "bugtracker": "https://github.com/sugarlabs/maze-activity",
     "homepage": "https://github.com/sugarlabs/maze-activity"
   },
-  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
+  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
   "icons": [],
   "id": "org.sugarlabs.Maze",
   "translation": {
@@ -129,8 +129,12 @@
   "name": "Maze",
   "summary": "A simple maze game",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "launchable": {
     "value": "org.sugarlabs.Maze.desktop",

--- a/backend/tests/snapshots/main__appstream_by_appid_fallback__test_appstream_by_appid.json
+++ b/backend/tests/snapshots/main__appstream_by_appid_fallback__test_appstream_by_appid.json
@@ -119,7 +119,7 @@
     "bugtracker": "https://github.com/sugarlabs/maze-activity",
     "homepage": "https://github.com/sugarlabs/maze-activity"
   },
-  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
+  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
   "icons": [],
   "id": "org.sugarlabs.Maze",
   "translation": {
@@ -129,8 +129,12 @@
   "name": "Maze",
   "summary": "A simple maze game",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "launchable": {
     "value": "org.sugarlabs.Maze.desktop",

--- a/backend/tests/snapshots/main__appstream_by_appid_locale__test_appstream_by_appid_locale.json
+++ b/backend/tests/snapshots/main__appstream_by_appid_locale__test_appstream_by_appid_locale.json
@@ -119,7 +119,7 @@
     "bugtracker": "https://github.com/sugarlabs/maze-activity",
     "homepage": "https://github.com/sugarlabs/maze-activity"
   },
-  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
+  "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
   "icons": [],
   "id": "org.sugarlabs.Maze",
   "translation": {
@@ -129,8 +129,12 @@
   "name": "Maze",
   "summary": "Ein simples Irrgartenspiel",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "launchable": {
     "value": "org.sugarlabs.Maze.desktop",

--- a/backend/tests/snapshots/main__collection_by_one_recently_updated__test_collection_by_one_recently_updated.json
+++ b/backend/tests/snapshots/main__collection_by_one_recently_updated__test_collection_by_one_recently_updated.json
@@ -10,9 +10,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886

--- a/backend/tests/snapshots/main__collection_by_one_recently_updated_locale__test_collection_by_one_recently_updated_locale.json
+++ b/backend/tests/snapshots/main__collection_by_one_recently_updated_locale__test_collection_by_one_recently_updated_locale.json
@@ -10,9 +10,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886

--- a/backend/tests/snapshots/main__collection_by_recently_updated__test_collection_by_recently_updated.json
+++ b/backend/tests/snapshots/main__collection_by_recently_updated__test_collection_by_recently_updated.json
@@ -10,9 +10,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -40,8 +46,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__collection_by_recently_updated_locale__test_collection_by_recently_updated_locale.json
+++ b/backend/tests/snapshots/main__collection_by_recently_updated_locale__test_collection_by_recently_updated_locale.json
@@ -10,9 +10,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -40,8 +46,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__popular_last_month__test_popular_last_month.json
+++ b/backend/tests/snapshots/main__popular_last_month__test_popular_last_month.json
@@ -11,8 +11,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -39,9 +45,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__popular_last_month_locale__test_popular_last_month.json
+++ b/backend/tests/snapshots/main__popular_last_month_locale__test_popular_last_month.json
@@ -11,8 +11,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -39,9 +45,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_description__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_description__test_search_query_by_appid.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_description_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_description_locale__test_search_query_by_appid_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_name__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_name__test_search_query_by_appid.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_name_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_name_locale__test_search_query_by_appid_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_partial_name_2__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_2__test_search_query_by_appid.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_partial_name_2_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_2_locale__test_search_query_by_appid_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_partial_name__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name__test_search_query_by_appid.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_partial_name_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_locale__test_search_query_by_appid_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_summary__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_summary__test_search_query_by_appid.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__search_query_by_summary_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_summary_locale__test_search_query_by_appid_locale.json
@@ -10,9 +10,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__trending_last_two_weeks__test_trending_last_two_weeks.json
+++ b/backend/tests/snapshots/main__trending_last_two_weeks__test_trending_last_two_weeks.json
@@ -11,8 +11,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -39,9 +45,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567

--- a/backend/tests/snapshots/main__trending_last_two_weeks_locale__test_trending_last_two_weeks_locale.json
+++ b/backend/tests/snapshots/main__trending_last_two_weeks_locale__test_trending_last_two_weeks_locale.json
@@ -11,8 +11,12 @@
       "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": null,
-      "categories": ["Office"],
-      "main_categories": ["Office"],
+      "categories": [
+        "Office"
+      ],
+      "main_categories": [
+        "Office"
+      ],
       "sub_categories": [],
       "developer_name": "Kingsoft Office Corporation",
       "verification_verified": false,
@@ -24,7 +28,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 971
@@ -39,9 +45,13 @@
       "project_license": "LicenseRef-proprietary",
       "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.webp",
-      "categories": ["Network"],
-      "main_categories": ["Network"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "main_categories": [
+        "Network"
+      ],
       "sub_categories": [],
       "developer_name": "AnyDesk Software GmbH",
       "verification_verified": false,
@@ -53,7 +63,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 886
@@ -68,9 +80,13 @@
       "project_license": "GPL-3.0-or-later",
       "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
-      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.webp",
-      "categories": ["Game"],
-      "main_categories": ["Game"],
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "main_categories": [
+        "Game"
+      ],
       "sub_categories": [],
       "developer_name": "Sugar Labs Community",
       "verification_verified": false,
@@ -82,7 +98,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 567


### PR DESCRIPTION
The compression of the current webp images isn't good enough, so needs to be redone. Use png for now.