### PR TITLE
Allow empty app names in emails

### DIFF
--- a/backend-node/emails/base.tsx
+++ b/backend-node/emails/base.tsx
@@ -16,7 +16,7 @@ import * as React from "react"
 
 const isProduction = process.env.NODE_ENV === "production"
 
-export function buildAppName(appId?: string, appName?: string) {
+export function buildAppName(appId?: string, appName?: string | null) {
   if (!appId && !appName) {
     return undefined
   }
@@ -36,7 +36,7 @@ export const Base = ({
   subject: string
   category: string
   appId?: string
-  appName?: string
+  appName?: string | null
   previewText: string
 }) => {
   const appNameAndId = buildAppName(appId, appName)

--- a/backend-node/emails/build-notification.tsx
+++ b/backend-node/emails/build-notification.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 export interface BuildNotificationEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "build_notification"
   subject: string
   previewText: string

--- a/backend-node/emails/developer-invite-accepted.tsx
+++ b/backend-node/emails/developer-invite-accepted.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 interface DeveloperInviteAcceptedEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "developer_invite_accepted"
   subject: string
   previewText: string

--- a/backend-node/emails/developer-invite-declined.tsx
+++ b/backend-node/emails/developer-invite-declined.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 interface DeveloperInviteDeclinedEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "developer_invite_declined"
   subject: string
   previewText: string

--- a/backend-node/emails/developer-invite.tsx
+++ b/backend-node/emails/developer-invite.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 interface DeveloperInviteEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "developer_invite"
   subject: string
   previewText: string

--- a/backend-node/emails/developer-left.tsx
+++ b/backend-node/emails/developer-left.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 interface DeveloperLeftEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "developer_left"
   subject: string
   previewText: string

--- a/backend-node/emails/moderation-held.tsx
+++ b/backend-node/emails/moderation-held.tsx
@@ -22,7 +22,7 @@ function alignArrays(a?: string[], b?: string[]): { a: string[]; b: string[] } {
 
 export interface ModerationEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "moderation_approved" | "moderation_held" | "moderation_rejected"
   subject: string
   previewText: string

--- a/backend-node/emails/upload-token-created.tsx
+++ b/backend-node/emails/upload-token-created.tsx
@@ -3,7 +3,7 @@ import { Base, buildAppName } from "./base"
 
 interface UploadTokenCreatedEmailProps {
   appId: string
-  appName?: string
+  appName: string | null
   category: "upload_token_created"
   subject: string
   previewText: string

--- a/backend-node/src/index.ts
+++ b/backend-node/src/index.ts
@@ -78,7 +78,7 @@ const EmailBody = z.object({
         .literal("upload_token_created")
         .openapi({ example: "upload_token_created" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       issuedTo: z.string().min(2).openapi({ example: "username" }),
       comment: z.string().min(2).openapi({ example: "My token" }),
       expiresAt: z.string().min(2).openapi({ example: "Tomorrow" }),
@@ -92,7 +92,7 @@ const EmailBody = z.object({
         .literal("moderation_rejected")
         .openapi({ example: "moderation_rejected" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       buildId: z.number().openapi({ example: 1 }),
       buildLogUrl: z
         .string()
@@ -109,7 +109,7 @@ const EmailBody = z.object({
         .literal("moderation_held")
         .openapi({ example: "moderation_held" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       buildId: z.number().openapi({ example: 1 }),
       buildLogUrl: z
         .string()
@@ -122,7 +122,7 @@ const EmailBody = z.object({
         .literal("moderation_approved")
         .openapi({ example: "moderation_approved" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       buildId: z.number().openapi({ example: 1 }),
       buildLogUrl: z
         .string()
@@ -142,7 +142,7 @@ const EmailBody = z.object({
         .literal("developer_left")
         .openapi({ example: "developer_left" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       login: z.string().min(2).openapi({ example: "testuser" }),
     }),
     z.object({
@@ -150,7 +150,7 @@ const EmailBody = z.object({
         .literal("developer_invite")
         .openapi({ example: "developer_invite" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       inviter: z.string().min(2).openapi({ example: "testuser" }),
     }),
     z.object({
@@ -158,7 +158,7 @@ const EmailBody = z.object({
         .literal("developer_invite_accepted")
         .openapi({ example: "developer_invite_accepted" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       login: z.string().min(2).openapi({ example: "testuser" }),
       references: z.string().min(3).openapi({
         example: "1212121",
@@ -169,7 +169,7 @@ const EmailBody = z.object({
         .literal("developer_invite_declined")
         .openapi({ example: "developer_invite_declined" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       login: z.string().min(2).openapi({ example: "testuser" }),
       references: z.string().min(3).openapi({
         example: "1212121",
@@ -180,7 +180,7 @@ const EmailBody = z.object({
         .literal("build_notification")
         .openapi({ example: "build_notification" }),
       appId: z.string().min(3).openapi({ example: "tv.kodi.Kodi" }),
-      appName: z.string().min(2).optional().openapi({ example: "Kodi" }),
+      appName: z.string().min(2).nullable().openapi({ example: "Kodi" }),
       diagnostics: z
         .array(z.any())
         .openapi({ example: ["problem 1", "problem 2"] }),


### PR DESCRIPTION
The id is still shows, this is relevant for base apps etc