### PR TITLE
Update localize.ts - Change incorrect flag for Gaeilge (Irish)

### DIFF
--- a/frontend/src/localize.ts
+++ b/frontend/src/localize.ts
@@ -464,7 +464,7 @@ export function getLanguageFlag(language: Language): string {
     case "ckb":
       return "🇮🇷"
     case "ga":
-      return "🇮🇳"
+      return "🇮🇪"
     case "kab":
       return ""
   }


### PR DESCRIPTION
The current flag set is 🇮🇳, which is India. 🇮🇪 is the flag of Ireland.