### PR TITLE
utils: Ignore display_length tags with side attribute set to longest

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -108,6 +108,7 @@ def appstream2dict(appstream_url=None) -> dict[str, dict]:
                 if any(
                     display_length_supports_mobile(display_length)
                     for display_length in display_lengths
+                    if display_length.attrib.get("side", "shortest") != "longest"
                 ):
                     isMobileFriendly = True
 


### PR DESCRIPTION
Not interested in figuring out another set of bounds, can be done if need arises later.