### PR TITLE
Metadata should return none not {}

### DIFF
--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -91,7 +91,7 @@ def parse_metadata(ini: str):
     parser.read_string(ini)
 
     if "Application" not in parser:
-        return {}
+        return None
 
     metadata = dict(parser["Application"])
 
@@ -194,7 +194,7 @@ def parse_summary(summary, sqldb):
         installed_size_be_uint = struct.pack("<Q", xa_cache[ref][0])
         installed_size = struct.unpack(">Q", installed_size_be_uint)[0]
 
-        parsed_metadata = parse_metadata(xa_cache[ref][2]) or {}
+        parsed_metadata = parse_metadata(xa_cache[ref][2])
 
         summary_dict[app_id]["branch"] = branch
         summary_dict[app_id]["download_size"] = download_size

--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -106,7 +106,7 @@ const Details: FunctionComponent<Props> = ({
 
     const children = [<LicenseInfo key={"license-info"} app={app} />]
 
-    if (summary !== null && summary.metadata !== null && app.type !== "addon") {
+    if (summary !== null && summary.metadata !== null) {
       children.unshift(
         <SafetyRating
           key={"safety-rating"}


### PR DESCRIPTION
The frontend reacts on None and not on {} and it would be way harder to always look at the content of an object instead.