### PR TITLE
Remove reactComponentAnnotation from Sentry Webpack plugin options

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -35,11 +35,6 @@ const sentryWebpackPluginOptions = {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
-  // Automatically annotate React components to show their full name in breadcrumbs and session replay
-  reactComponentAnnotation: {
-    enabled: true,
-  },
-
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
   // This can increase your server load as well as your hosting bill.
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-


### PR DESCRIPTION
This causes problems with the search, as it ends up passing parameters to a fragment