### PR TITLE
nginx: Reapply private no-cache headers for root redirect

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -187,8 +187,7 @@ http {
         }
 
         location = / {
-            add_header Surrogate-Control "no-cache";
-            add_header Cache-Control "public, max-age=3600";
+            add_header Cache-Control "private, max-age=0, no-cache, no-store";
             return 302 https://flathub.org/$detected_locale/$is_args$args;
         }
 


### PR DESCRIPTION
Reapplies https://github.com/flathub-infra/website/commit/afd6a84800ffa65838d602a01eb538a2e55648dc which was reverted in https://github.com/flathub-infra/website/pull/5655 for some reason.

This should fix the issue where locale redirection using Accept-Language header is not working due to caching.

```
curl -H "Accept-Language: de" -sIL "https://flathub.org"|grep -E "^(HTTP|location|x-middleware-redirect|x-cache)"
HTTP/2 302
location: https://flathub.org/en/
x-cache: MISS, HIT
x-cache-hits: 0, 2
HTTP/2 308
location: /en
x-cache: MISS, MISS
x-cache-hits: 0, 0
HTTP/2 200
x-cache: MISS, MISS
x-cache-hits: 0, 0

→ curl -H "Accept-Language: de" -sIL "https://flathub.org/?foobar=$(date +%s)"|grep -E "^(HTTP|location|x-middleware-redirect|x-cache)"
HTTP/2 302
location: https://flathub.org/de/?foobar=1762924754
x-cache: MISS, MISS
x-cache-hits: 0, 0
HTTP/2 308
location: /de?foobar=1762924754
x-cache: MISS, MISS
x-cache-hits: 0, 0
HTTP/2 200
x-cache: MISS, MISS
x-cache-hits: 0, 0
```