### PR TITLE
feat: improve subheader stats display and download size formatting

### DIFF
--- a/frontend/src/components/application/sub-header/StatsModal.tsx
+++ b/frontend/src/components/application/sub-header/StatsModal.tsx
@@ -77,24 +77,22 @@ const StatsModal = ({
     })
   }
 
-  if (countryData.length > 0) {
-    tabs.push({
-      name: t("country-statistics"),
-      content: (
-        <div className="flex flex-col items-center p-4 w-full">
-          <ContainerWorldMap countryData={countryData} />
-          <p className="mt-2 text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray">
-            {t("since-x", {
-              date: countryStatisticsStartDate.toLocaleDateString(
-                getIntlLocale(locale),
-              ),
-            })}
-          </p>
-        </div>
-      ),
-      replacePadding: "p-0",
-    })
-  }
+  tabs.push({
+    name: t("country-statistics"),
+    content: (
+      <div className="flex flex-col items-center p-4 w-full">
+        <ContainerWorldMap countryData={countryData} />
+        <p className="mt-2 text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray">
+          {t("since-x", {
+            date: countryStatisticsStartDate.toLocaleDateString(
+              getIntlLocale(locale),
+            ),
+          })}
+        </p>
+      </div>
+    ),
+    replacePadding: "p-0",
+  })
 
   return (
     <Modal
@@ -108,14 +106,7 @@ const StatsModal = ({
         {stats.installs_total.toLocaleString(getIntlLocale(locale))}{" "}
         {t("sub-header.total-installs")}
       </div>
-      {tabs.length > 0 ? (
-        <Tabs tabs={tabs} tabsIdentifier="stats-modal" />
-      ) : (
-        <div className="text-center text-sm text-flathub-sonic-silver dark:text-flathub-spanish-gray">
-          {t("installs")}:{" "}
-          {stats.installs_total.toLocaleString(getIntlLocale(locale))}
-        </div>
-      )}
+      <Tabs tabs={tabs} tabsIdentifier="stats-modal" />
     </Modal>
   )
 }

--- a/frontend/src/components/application/sub-header/SubHeader.tsx
+++ b/frontend/src/components/application/sub-header/SubHeader.tsx
@@ -77,7 +77,7 @@ const SubHeader: FunctionComponent<SubHeaderProps> = ({
     items.push(
       <SubHeaderItem key="download" onClick={() => setDownloadSizeOpen(true)}>
         <span className="inline-flex items-center rounded-full bg-flathub-gainsborow/60 px-3 py-1 text-sm font-bold leading-none tabular-nums dark:bg-flathub-granite-gray/60">
-          {calculateHumanReadableSize(summary.download_size)}
+          {calculateHumanReadableSize(summary.download_size, true)}
         </span>
         <span className="text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray/80">
           {t("sub-header.download")}
@@ -151,25 +151,24 @@ const SubHeader: FunctionComponent<SubHeaderProps> = ({
     </SubHeaderItem>,
   )
 
-  // Downloads/Month
-  if (stats && stats.installs_last_month > 0) {
-    items.push(
-      <SubHeaderItem key="stats" onClick={() => setStatsOpen(true)}>
-        <span className="inline-flex items-center rounded-full bg-flathub-gainsborow/60 px-3 py-1 text-sm font-bold leading-none tabular-nums dark:bg-flathub-granite-gray/60">
-          {stats.installs_last_month.toLocaleString(getIntlLocale(locale))}
-        </span>
-        <span className="text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray/80">
-          {t("sub-header.downloads-per-month")}
-        </span>
-      </SubHeaderItem>,
-    )
-  }
+  // Downloads/Month - always show, defaulting to 0
+  const installsLastMonth = stats?.installs_last_month ?? 0
+  items.push(
+    <SubHeaderItem key="stats" onClick={() => setStatsOpen(true)}>
+      <span className="inline-flex items-center rounded-full bg-flathub-gainsborow/60 px-3 py-1 text-sm font-bold leading-none tabular-nums dark:bg-flathub-granite-gray/60">
+        {installsLastMonth.toLocaleString(getIntlLocale(locale))}
+      </span>
+      <span className="text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray/80">
+        {t("sub-header.downloads-per-month")}
+      </span>
+    </SubHeaderItem>,
+  )
 
   return (
     <>
       <section
         aria-label={t("app-information")}
-        className="col-start-2 flex flex-wrap items-stretch justify-between pb-4"
+        className="col-start-2 flex flex-wrap items-stretch justify-between pb-4 lg:px-16 xl:px-24 2xl:px-32"
       >
         {items}
       </section>
@@ -205,14 +204,21 @@ const SubHeader: FunctionComponent<SubHeaderProps> = ({
         isMobileFriendly={isMobileFriendly}
       />
 
-      {stats && (
-        <StatsModal
-          isOpen={statsOpen}
-          onClose={() => setStatsOpen(false)}
-          stats={stats}
-          locale={locale}
-        />
-      )}
+      <StatsModal
+        isOpen={statsOpen}
+        onClose={() => setStatsOpen(false)}
+        stats={
+          stats ?? {
+            installs_total: 0,
+            installs_per_day: {},
+            installs_per_country: {},
+            installs_last_month: 0,
+            installs_last_7_days: 0,
+            id: app.id,
+          }
+        }
+        locale={locale}
+      />
     </>
   )
 }

--- a/frontend/src/size.ts
+++ b/frontend/src/size.ts
@@ -1,4 +1,4 @@
-export function calculateHumanReadableSize(size: number) {
+export function calculateHumanReadableSize(size: number, rounded = false) {
   // First letters of multiples of 2, more precisely of 2^10.
   const UNIT_CHARS = ["B", "K", "M", "G", "T", "P", "E", "Z", "Y"]
   const i = "i" // From "binary".
@@ -12,11 +12,10 @@ export function calculateHumanReadableSize(size: number) {
     UNIT_CHARS.length - 1,
   )
   const value = size / Math.pow(POW10, pow10Count)
-  return (
-    // .toFixed() will round to fixed number of digits,
-    // parseFloat() will convert strings like 1.00 to 1 and 1.10 to 1.1.
-    parseFloat(value.toFixed(2)).toString() +
-    " " +
-    `${UNIT_CHARS[pow10Count]}${i}${UNIT_CHARS[0]}`
-  )
+  const formatted = rounded
+    ? Math.round(value).toString()
+    : // .toFixed() will round to fixed number of digits,
+      // parseFloat() will convert strings like 1.00 to 1 and 1.10 to 1.1.
+      parseFloat(value.toFixed(2)).toString()
+  return formatted + " " + `${UNIT_CHARS[pow10Count]}${i}${UNIT_CHARS[0]}`
 }


### PR DESCRIPTION
- Always show downloads/month stat (defaults to 0 when no data)
- Stats modal always renders with working country map tab
- Add padding to subheader on larger screens
- Add rounded option to calculateHumanReadableSize