### PR TITLE
feat(frontend): Add HealthFitness category

### DIFF
--- a/frontend/app/[locale]/(home)/page.tsx
+++ b/frontend/app/[locale]/(home)/page.tsx
@@ -36,6 +36,7 @@ const categoryOrder: MainCategory[] = [
   MainCategory.network,
   MainCategory.development,
   MainCategory.science,
+  MainCategory.healthfitness,
   MainCategory.system,
   MainCategory.utility,
 ]

--- a/frontend/app/[locale]/home-client.tsx
+++ b/frontend/app/[locale]/home-client.tsx
@@ -55,6 +55,10 @@ interface HomeClientProps {
 function MobileSection({ mobile }: { mobile: MeilisearchResponseAppsIndex }) {
   const t = useTranslations()
 
+  if (mobile.hits.length === 0) {
+    return null
+  }
+
   return (
     <ApplicationSectionGradient
       mobile={mobile}
@@ -128,57 +132,82 @@ function CategorySection({
     category: MainCategory
     apps: MeilisearchResponseAppsIndex
   }[]
-  mobileSection: ReactElement
-  gameSection: ReactElement
+  mobileSection: ReactElement | null
+  gameSection: ReactElement | null
   afterFirstCategoryBlockSelection?: HomepageCuratedAppSelection
 }) {
   const t = useTranslations()
 
-  const categorySections = useMemo(
+  const topAppsWithResults = useMemo(
     () =>
-      topAppsByCategory.map((sectionData) => ({
-        category: sectionData.category,
-        applications: sectionData.apps.hits.map((app) =>
-          mapAppsIndexToAppstreamListItem(app),
-        ),
-      })),
+      topAppsByCategory
+        .map((sectionData) => ({
+          category: sectionData.category,
+          applications: sectionData.apps.hits.map((app) =>
+            mapAppsIndexToAppstreamListItem(app),
+          ),
+        }))
+        .filter((sectionData) => sectionData.applications.length > 0),
     [topAppsByCategory],
   )
 
-  return (
-    <>
-      {categorySections.map((sectionData, i) => (
-        <Fragment key={`categorySection${sectionData.category}`}>
-          <div>
-            {i === 3 && <div className="mb-10">{mobileSection}</div>}
-            {i === 5 && <div className="mb-10">{gameSection}</div>}
-            <ApplicationSection
-              type="withCustomHeader"
-              href={`/apps/category/${encodeURIComponent(sectionData.category)}`}
-              applications={sectionData.applications}
-              numberOfApps={6}
-              customHeader={
-                <>
-                  <header className="mb-3 flex max-w-full flex-row content-center justify-between">
-                    <h1 className="my-auto text-2xl font-bold">
-                      {categoryToName(sectionData.category, t)}
-                    </h1>
-                  </header>
-                </>
-              }
-              showMore={true}
-              moreText={t(`more-${sectionData.category.toLowerCase()}`)}
-            />
-          </div>
-          {i === 0 && afterFirstCategoryBlockSelection && (
-            <ScheduledAppSelectionSection
-              selection={afterFirstCategoryBlockSelection}
-            />
-          )}
-        </Fragment>
-      ))}
-    </>
+  const renderedSections = useMemo(
+    () =>
+      topAppsWithResults.flatMap((sectionData, index) => {
+        const sections = [
+          <Fragment key={`categorySection${sectionData.category}`}>
+            <div>
+              <ApplicationSection
+                type="withCustomHeader"
+                href={`/apps/category/${encodeURIComponent(sectionData.category)}`}
+                applications={sectionData.applications}
+                numberOfApps={6}
+                customHeader={
+                  <>
+                    <header className="mb-3 flex max-w-full flex-row content-center justify-between">
+                      <h1 className="my-auto text-2xl font-bold">
+                        {categoryToName(sectionData.category, t)}
+                      </h1>
+                    </header>
+                  </>
+                }
+                showMore={true}
+                moreText={t(`more-${sectionData.category.toLowerCase()}`)}
+              />
+            </div>
+            {index === 0 && afterFirstCategoryBlockSelection && (
+              <ScheduledAppSelectionSection
+                selection={afterFirstCategoryBlockSelection}
+              />
+            )}
+          </Fragment>,
+        ]
+        if (index === 3 && mobileSection) {
+          sections.push(
+            <div key="mobileSection" className="mb-10">
+              {mobileSection}
+            </div>,
+          )
+        }
+
+        if (index === 5 && gameSection) {
+          sections.push(
+            <div key="gameSection" className="mb-10">
+              {gameSection}
+            </div>,
+          )
+        }
+
+        return sections
+      }),
+    [gameSection, mobileSection, t, topAppsWithResults],
   )
+
+  if (renderedSections.length === 0) {
+    return null
+  }
+
+  return <>{renderedSections}</>
 }
 
 function TopSection({
@@ -222,9 +251,17 @@ function TopSection({
 
   const applications = useMemo(
     () =>
-      selectedApps.apps.hits.map((app) => mapAppsIndexToAppstreamListItem(app)),
-    [selectedApps.apps.hits],
+      selectedApps
+        ? selectedApps.apps.hits.map((app) =>
+            mapAppsIndexToAppstreamListItem(app),
+          )
+        : [],
+    [selectedApps],
   )
+
+  if (!selectedApps) {
+    return null
+  }
 
   return (
     <ApplicationSection
@@ -285,21 +322,25 @@ function HomeClient({
       name: "updated",
       moreLink: "/apps/collection/recently-updated",
     },
-  ]
+  ].filter((section) => section.apps.hits.length > 0)
 
   const mobileSection = <MobileSection mobile={mobile} />
 
-  const gameSection = (
-    <GameSection
-      games={games}
-      emulators={emulators}
-      gameLaunchers={gameLaunchers}
-      gameTools={gameTools}
-    />
-  )
+  const gameSection =
+    games.hits.length > 0 ||
+    emulators.hits.length > 0 ||
+    gameLaunchers.hits.length > 0 ||
+    gameTools.hits.length > 0 ? (
+      <GameSection
+        games={games}
+        emulators={emulators}
+        gameLaunchers={gameLaunchers}
+        gameTools={gameTools}
+      />
+    ) : null
 
   return (
-    <div className="max-w-11/12 mx-auto my-0 mt-4 w-11/12 space-y-10 2xl:w-[1400px] 2xl:max-w-[1400px]">
+    <div className="max-w-11/12 mx-auto my-0 mt-4 w-11/12 space-y-10 2xl:w-350 2xl:max-w-350">
       <YearInReviewBanner />
       <div className="space-y-4">
         {heroBannerData.length > 0 && (
@@ -316,7 +357,7 @@ function HomeClient({
               "rounded-xl",
               "flex min-w-0 items-center gap-4",
               "bg-repeat",
-              "bg-[length:420px_420px]",
+              "bg-size-[420px_420px]",
               "bg-bottom",
               "dark:bg-[url('https://dl.flathub.org/assets/_next/public/img/card-background-dark.webp')]",
               "bg-[url('https://dl.flathub.org/assets/_next/public/img/card-background.webp')]",
@@ -370,7 +411,7 @@ function HomeClient({
         <ScheduledAppSelectionSection selection={afterHeroSelection} />
       )}
 
-      <TopSection topApps={topAppsData} />
+      {topAppsData.length > 0 && <TopSection topApps={topAppsData} />}
 
       {afterTopAppsSelection && (
         <ScheduledAppSelectionSection selection={afterTopAppsSelection} />
@@ -378,7 +419,7 @@ function HomeClient({
 
       <CategorySection
         topAppsByCategory={topAppsByCategory}
-        mobileSection={mobileSection}
+        mobileSection={mobile.hits.length > 0 ? mobileSection : null}
         gameSection={gameSection}
         afterFirstCategoryBlockSelection={afterFirstCategoryBlockSelection}
       />

--- a/frontend/app/[locale]/home-client.tsx
+++ b/frontend/app/[locale]/home-client.tsx
@@ -55,6 +55,10 @@ interface HomeClientProps {
 function MobileSection({ mobile }: { mobile: MeilisearchResponseAppsIndex }) {
   const t = useTranslations()
 
+  if (mobile.hits.length === 0) {
+    return null
+  }
+
   return (
     <ApplicationSectionGradient
       mobile={mobile}
@@ -128,57 +132,82 @@ function CategorySection({
     category: MainCategory
     apps: MeilisearchResponseAppsIndex
   }[]
-  mobileSection: ReactElement
-  gameSection: ReactElement
+  mobileSection: ReactElement | null
+  gameSection: ReactElement | null
   afterFirstCategoryBlockSelection?: HomepageCuratedAppSelection
 }) {
   const t = useTranslations()
 
-  const categorySections = useMemo(
+  const topAppsWithResults = useMemo(
     () =>
-      topAppsByCategory.map((sectionData) => ({
-        category: sectionData.category,
-        applications: sectionData.apps.hits.map((app) =>
-          mapAppsIndexToAppstreamListItem(app),
-        ),
-      })),
+      topAppsByCategory
+        .map((sectionData) => ({
+          category: sectionData.category,
+          applications: sectionData.apps.hits.map((app) =>
+            mapAppsIndexToAppstreamListItem(app),
+          ),
+        }))
+        .filter((sectionData) => sectionData.applications.length > 0),
     [topAppsByCategory],
   )
 
-  return (
-    <>
-      {categorySections.map((sectionData, i) => (
-        <Fragment key={`categorySection${sectionData.category}`}>
-          <div>
-            {i === 4 && <div className="mb-10">{mobileSection}</div>}
-            {i === 6 && <div className="mb-10">{gameSection}</div>}
-            <ApplicationSection
-              type="withCustomHeader"
-              href={`/apps/category/${encodeURIComponent(sectionData.category)}`}
-              applications={sectionData.applications}
-              numberOfApps={6}
-              customHeader={
-                <>
-                  <header className="mb-3 flex max-w-full flex-row content-center justify-between">
-                    <h1 className="my-auto text-2xl font-bold">
-                      {categoryToName(sectionData.category, t)}
-                    </h1>
-                  </header>
-                </>
-              }
-              showMore={true}
-              moreText={t(`more-${sectionData.category.toLowerCase()}`)}
-            />
-          </div>
-          {i === 0 && afterFirstCategoryBlockSelection && (
-            <ScheduledAppSelectionSection
-              selection={afterFirstCategoryBlockSelection}
-            />
-          )}
-        </Fragment>
-      ))}
-    </>
+  const renderedSections = useMemo(
+    () =>
+      topAppsWithResults.flatMap((sectionData, index) => {
+        const sections = [
+          <Fragment key={`categorySection${sectionData.category}`}>
+            <div>
+              <ApplicationSection
+                type="withCustomHeader"
+                href={`/apps/category/${encodeURIComponent(sectionData.category)}`}
+                applications={sectionData.applications}
+                numberOfApps={6}
+                customHeader={
+                  <>
+                    <header className="mb-3 flex max-w-full flex-row content-center justify-between">
+                      <h1 className="my-auto text-2xl font-bold">
+                        {categoryToName(sectionData.category, t)}
+                      </h1>
+                    </header>
+                  </>
+                }
+                showMore={true}
+                moreText={t(`more-${sectionData.category.toLowerCase()}`)}
+              />
+            </div>
+            {index === 0 && afterFirstCategoryBlockSelection && (
+              <ScheduledAppSelectionSection
+                selection={afterFirstCategoryBlockSelection}
+              />
+            )}
+          </Fragment>,
+        ]
+        if (index === 4 && mobileSection) {
+          sections.push(
+            <div key="mobileSection" className="mb-10">
+              {mobileSection}
+            </div>,
+          )
+        }
+
+        if (index === 6 && gameSection) {
+          sections.push(
+            <div key="gameSection" className="mb-10">
+              {gameSection}
+            </div>,
+          )
+        }
+
+        return sections
+      }),
+    [gameSection, mobileSection, t, topAppsWithResults],
   )
+
+  if (renderedSections.length === 0) {
+    return null
+  }
+
+  return <>{renderedSections}</>
 }
 
 function TopSection({
@@ -222,9 +251,17 @@ function TopSection({
 
   const applications = useMemo(
     () =>
-      selectedApps.apps.hits.map((app) => mapAppsIndexToAppstreamListItem(app)),
-    [selectedApps.apps.hits],
+      selectedApps
+        ? selectedApps.apps.hits.map((app) =>
+            mapAppsIndexToAppstreamListItem(app),
+          )
+        : [],
+    [selectedApps],
   )
+
+  if (!selectedApps) {
+    return null
+  }
 
   return (
     <ApplicationSection
@@ -285,21 +322,25 @@ function HomeClient({
       name: "updated",
       moreLink: "/apps/collection/recently-updated",
     },
-  ]
+  ].filter((section) => section.apps.hits.length > 0)
 
   const mobileSection = <MobileSection mobile={mobile} />
 
-  const gameSection = (
-    <GameSection
-      games={games}
-      emulators={emulators}
-      gameLaunchers={gameLaunchers}
-      gameTools={gameTools}
-    />
-  )
+  const gameSection =
+    games.hits.length > 0 ||
+    emulators.hits.length > 0 ||
+    gameLaunchers.hits.length > 0 ||
+    gameTools.hits.length > 0 ? (
+      <GameSection
+        games={games}
+        emulators={emulators}
+        gameLaunchers={gameLaunchers}
+        gameTools={gameTools}
+      />
+    ) : null
 
   return (
-    <div className="max-w-11/12 mx-auto my-0 mt-4 w-11/12 space-y-10 2xl:w-[1400px] 2xl:max-w-[1400px]">
+    <div className="max-w-11/12 mx-auto my-0 mt-4 w-11/12 space-y-10 2xl:w-350 2xl:max-w-350">
       <YearInReviewBanner />
       <div className="space-y-4">
         {heroBannerData.length > 0 && (
@@ -316,7 +357,7 @@ function HomeClient({
               "rounded-xl",
               "flex min-w-0 items-center gap-4",
               "bg-repeat",
-              "bg-[length:420px_420px]",
+              "bg-size-[420px_420px]",
               "bg-bottom",
               "dark:bg-[url('https://dl.flathub.org/assets/_next/public/img/card-background-dark.webp')]",
               "bg-[url('https://dl.flathub.org/assets/_next/public/img/card-background.webp')]",
@@ -370,7 +411,7 @@ function HomeClient({
         <ScheduledAppSelectionSection selection={afterHeroSelection} />
       )}
 
-      <TopSection topApps={topAppsData} />
+      {topAppsData.length > 0 && <TopSection topApps={topAppsData} />}
 
       {afterTopAppsSelection && (
         <ScheduledAppSelectionSection selection={afterTopAppsSelection} />
@@ -378,7 +419,7 @@ function HomeClient({
 
       <CategorySection
         topAppsByCategory={topAppsByCategory}
-        mobileSection={mobileSection}
+        mobileSection={mobile.hits.length > 0 ? mobileSection : null}
         gameSection={gameSection}
         afterFirstCategoryBlockSelection={afterFirstCategoryBlockSelection}
       />

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -234,6 +234,7 @@
   "developer-tools": "Developer Tools",
   "games": "Games",
   "graphics-and-photography": "Graphics & Photography",
+  "health-and-fitness": "Health & Fitness",
   "networking": "Networking",
   "productivity": "Productivity",
   "utilities": "Utilities",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -219,6 +219,7 @@
   "developer-tools": "Developer Tools",
   "games": "Games",
   "graphics-and-photography": "Graphics & Photography",
+  "health-and-fitness": "Health & Fitness",
   "networking": "Networking",
   "productivity": "Productivity",
   "utilities": "Utilities",

--- a/frontend/src/components/application/YearInReview.tsx
+++ b/frontend/src/components/application/YearInReview.tsx
@@ -28,6 +28,7 @@ const categoryOrder: MainCategory[] = [
   MainCategory.network,
   MainCategory.development,
   MainCategory.science,
+  MainCategory.healthfitness,
   MainCategory.system,
   MainCategory.utility,
 ]


### PR DESCRIPTION
HealthFitness was recently added as a main category on FreeDesktop xdg-specs.
https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/98#note_3339833
https://specifications.freedesktop.org/menu/latest/category-registry.html

This change should add support for displaying this category in Flathub.
I'm having some issues running the app locally with podman compose so I wasn't able to test this change sadly :frowning_face: 



