### PR TITLE
fix(backend): support localized keywords in tag collection pages

### DIFF
--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -61,6 +61,7 @@ def add_to_search(app_id: str, app: dict, apps_locale: dict) -> dict:
     type = "desktop-application" if app.get("type") == "desktop" else app.get("type")
 
     translations = {}
+    localized_keywords_set: set[str] = set(search_keywords or [])
     for key, apps in apps_locale.items():
         if key in localize.LANGUAGES:
             if not isinstance(apps, dict):
@@ -80,6 +81,7 @@ def add_to_search(app_id: str, app: dict, apps_locale: dict) -> dict:
                         ]
                         if keywords:
                             filtered_translations[k] = keywords
+                            localized_keywords_set.update(keywords)
 
             if "description" in filtered_translations:
                 filtered_translations["description"] = re.sub(
@@ -88,6 +90,10 @@ def add_to_search(app_id: str, app: dict, apps_locale: dict) -> dict:
 
             if filtered_translations:
                 translations[key] = filtered_translations
+
+    localized_keywords = (
+        sorted(localized_keywords_set) if localized_keywords_set else None
+    )
 
     # order of the dict is important for attribute ranking
     return {
@@ -98,6 +104,7 @@ def add_to_search(app_id: str, app: dict, apps_locale: dict) -> dict:
         "summary": app["summary"],
         "translations": translations,
         "keywords": search_keywords,
+        "localized_keywords": localized_keywords,
         "project_license": project_license,
         "is_free_license": AppStream.license_is_free_license(project_license),
         "app_id": app_id,

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -44,6 +44,7 @@ class MeilisearchResponseLimited[T](BaseModel):
 class AppsIndex(BaseModel):
     name: str
     keywords: list[str] | None = None
+    localized_keywords: list[str] | None = None
     summary: str
     description: str
     id: str
@@ -142,6 +143,7 @@ def _configure_meilisearch_index(client):
             "arches",
             "icon",
             "keywords",
+            "localized_keywords",
             "isMobileFriendly",
         ]
     )
@@ -698,7 +700,7 @@ def get_by_keyword(
                 "",
                 {
                     "filter": [
-                        f"keywords = '{escaped_keyword}'",
+                        f"localized_keywords = '{escaped_keyword}'",
                         "type IN [console-application, desktop-application]",
                         "NOT icon IS NULL",
                     ],

--- a/backend/tests/snapshots/main__apps_by_category__test_apps_by_category.json
+++ b/backend/tests/snapshots/main__apps_by_category__test_apps_by_category.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__apps_by_category_locale__test_apps_by_category_locale.json
+++ b/backend/tests/snapshots/main__apps_by_category_locale__test_apps_by_category_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__apps_by_developer__test_apps_by_developer.json
+++ b/backend/tests/snapshots/main__apps_by_developer__test_apps_by_developer.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__apps_by_developer_locale__test_apps_by_developer_locale.json
+++ b/backend/tests/snapshots/main__apps_by_developer_locale__test_apps_by_developer_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__collection_by_one_recently_updated__test_collection_by_one_recently_updated.json
+++ b/backend/tests/snapshots/main__collection_by_one_recently_updated__test_collection_by_one_recently_updated.json
@@ -3,6 +3,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,

--- a/backend/tests/snapshots/main__collection_by_one_recently_updated_locale__test_collection_by_one_recently_updated_locale.json
+++ b/backend/tests/snapshots/main__collection_by_one_recently_updated_locale__test_collection_by_one_recently_updated_locale.json
@@ -3,8 +3,9 @@
     {
       "name": "AnyDesk",
       "keywords": null,
-      "summary": "Con\u00e9ctese a un ordenador de forma remota",
-      "description": "Gracias a AnyDesk, contar\u00e1 con conexiones seguras y fiables de escritorio remoto para profesionales inform\u00e1ticos y usuarios en movimiento.",
+      "localized_keywords": null,
+      "summary": "Conéctese a un ordenador de forma remota",
+      "description": "Gracias a AnyDesk, contará con conexiones seguras y fiables de escritorio remoto para profesionales informáticos y usuarios en movimiento.",
       "id": "com_anydesk_Anydesk",
       "type": "desktop-application",
       "project_license": "LicenseRef-proprietary",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,

--- a/backend/tests/snapshots/main__collection_by_recently_updated__test_collection_by_recently_updated.json
+++ b/backend/tests/snapshots/main__collection_by_recently_updated__test_collection_by_recently_updated.json
@@ -3,6 +3,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,
@@ -33,6 +36,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -63,7 +69,25 @@
     },
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__collection_by_recently_updated_locale__test_collection_by_recently_updated_locale.json
+++ b/backend/tests/snapshots/main__collection_by_recently_updated_locale__test_collection_by_recently_updated_locale.json
@@ -3,8 +3,9 @@
     {
       "name": "AnyDesk",
       "keywords": null,
-      "summary": "Con\u00e9ctese a un ordenador de forma remota",
-      "description": "Gracias a AnyDesk, contar\u00e1 con conexiones seguras y fiables de escritorio remoto para profesionales inform\u00e1ticos y usuarios en movimiento.",
+      "localized_keywords": null,
+      "summary": "Conéctese a un ordenador de forma remota",
+      "description": "Gracias a AnyDesk, contará con conexiones seguras y fiables de escritorio remoto para profesionales informáticos y usuarios en movimiento.",
       "id": "com_anydesk_Anydesk",
       "type": "desktop-application",
       "project_license": "LicenseRef-proprietary",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,
@@ -33,6 +36,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -63,9 +69,27 @@
     },
     {
       "name": "Laberinto",
-      "keywords": ["laberinto", "rompecabezas", "juego"],
+      "keywords": [
+        "laberinto",
+        "rompecabezas",
+        "juego"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Un simple juego de laberintos",
-      "description": "\u00bfEres bueno encontrando la salida de situaciones dif\u00edciles?",
+      "description": "¿Eres bueno encontrando la salida de situaciones difíciles?",
       "id": "org_sugarlabs_Maze",
       "type": "desktop-application",
       "project_license": "GPL-3.0-or-later",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__collection_favorites__test_collection_favorites.json
+++ b/backend/tests/snapshots/main__collection_favorites__test_collection_favorites.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,
@@ -33,6 +53,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +75,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -64,6 +87,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,

--- a/backend/tests/snapshots/main__collection_favorites_locale__test_collection_favorites_locale.json
+++ b/backend/tests/snapshots/main__collection_favorites_locale__test_collection_favorites_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "Rätsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,
@@ -33,6 +53,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +75,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -64,6 +87,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,

--- a/backend/tests/snapshots/main__collection_keyword__test_collection_keyword.json
+++ b/backend/tests/snapshots/main__collection_keyword__test_collection_keyword.json
@@ -3,6 +3,7 @@
     {
       "name": "Maze",
       "keywords": ["maze", "puzzle", "game"],
+      "localized_keywords": ["Labyrinth", "R\u00e4tsel", "Spiel", "casse-t\u00eate", "game", "jeu", "juego", "laberinto", "labyrinthe", "maze", "puzzle", "rompecabezas"],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",

--- a/backend/tests/snapshots/main__collection_recently_added__test_collection_recently_added.json
+++ b/backend/tests/snapshots/main__collection_recently_added__test_collection_recently_added.json
@@ -3,6 +3,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 0,
       "installs_last_month": 653,
@@ -33,6 +36,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 0,
       "installs_last_month": 1151,
@@ -63,7 +69,25 @@
     },
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__collection_recently_added_locale__test_collection_recently_added_locale.json
+++ b/backend/tests/snapshots/main__collection_recently_added_locale__test_collection_recently_added_locale.json
@@ -3,8 +3,9 @@
     {
       "name": "AnyDesk",
       "keywords": null,
-      "summary": "Con\u00e9ctese a un ordenador de forma remota",
-      "description": "Gracias a AnyDesk, contar\u00e1 con conexiones seguras y fiables de escritorio remoto para profesionales inform\u00e1ticos y usuarios en movimiento.",
+      "localized_keywords": null,
+      "summary": "Conéctese a un ordenador de forma remota",
+      "description": "Gracias a AnyDesk, contará con conexiones seguras y fiables de escritorio remoto para profesionales informáticos y usuarios en movimiento.",
       "id": "com_anydesk_Anydesk",
       "type": "desktop-application",
       "project_license": "LicenseRef-proprietary",
@@ -23,7 +24,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 0,
       "installs_last_month": 653,
@@ -33,6 +36,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 0,
       "installs_last_month": 1151,
@@ -63,9 +69,27 @@
     },
     {
       "name": "Laberinto",
-      "keywords": ["laberinto", "rompecabezas", "juego"],
+      "keywords": [
+        "laberinto",
+        "rompecabezas",
+        "juego"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Un simple juego de laberintos",
-      "description": "\u00bfEres bueno encontrando la salida de situaciones dif\u00edciles?",
+      "description": "¿Eres bueno encontrando la salida de situaciones difíciles?",
       "id": "org_sugarlabs_Maze",
       "type": "desktop-application",
       "project_license": "GPL-3.0-or-later",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__popular_last_month__test_popular_last_month.json
+++ b/backend/tests/snapshots/main__popular_last_month__test_popular_last_month.json
@@ -3,6 +3,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -24,7 +25,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -34,6 +37,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,
@@ -63,7 +69,25 @@
     },
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__popular_last_month_locale__test_popular_last_month_locale.json
+++ b/backend/tests/snapshots/main__popular_last_month_locale__test_popular_last_month_locale.json
@@ -3,6 +3,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -24,7 +25,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -34,8 +37,9 @@
     {
       "name": "AnyDesk",
       "keywords": null,
-      "summary": "Con\u00e9ctese a un ordenador de forma remota",
-      "description": "Gracias a AnyDesk, contar\u00e1 con conexiones seguras y fiables de escritorio remoto para profesionales inform\u00e1ticos y usuarios en movimiento.",
+      "localized_keywords": null,
+      "summary": "Conéctese a un ordenador de forma remota",
+      "description": "Gracias a AnyDesk, contará con conexiones seguras y fiables de escritorio remoto para profesionales informáticos y usuarios en movimiento.",
       "id": "com_anydesk_Anydesk",
       "type": "desktop-application",
       "project_license": "LicenseRef-proprietary",
@@ -54,7 +58,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,
@@ -63,9 +69,27 @@
     },
     {
       "name": "Laberinto",
-      "keywords": ["laberinto", "rompecabezas", "juego"],
+      "keywords": [
+        "laberinto",
+        "rompecabezas",
+        "juego"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Un simple juego de laberintos",
-      "description": "\u00bfEres bueno encontrando la salida de situaciones dif\u00edciles?",
+      "description": "¿Eres bueno encontrando la salida de situaciones difíciles?",
       "id": "org_sugarlabs_Maze",
       "type": "desktop-application",
       "project_license": "GPL-3.0-or-later",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_description__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_description__test_search_query_by_appid.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_description_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_description_locale__test_search_query_by_appid_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_name__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_name__test_search_query_by_appid.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_name_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_name_locale__test_search_query_by_appid_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_partial_name_2__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_2__test_search_query_by_appid.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_partial_name_2_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_2_locale__test_search_query_by_appid_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_partial_name__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name__test_search_query_by_appid.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_partial_name_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_partial_name_locale__test_search_query_by_appid_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_summary__test_search_query_by_appid.json
+++ b/backend/tests/snapshots/main__search_query_by_summary__test_search_query_by_appid.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__search_query_by_summary_locale__test_search_query_by_appid_locale.json
+++ b/backend/tests/snapshots/main__search_query_by_summary_locale__test_search_query_by_appid_locale.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Irrgarten",
-      "keywords": ["Labyrinth", "R\u00e4tsel", "Spiel"],
+      "keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Ein simples Irrgartenspiel",
       "description": "Gut deinen Weg aus einer schwierigen Situation zu finden?",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,

--- a/backend/tests/snapshots/main__trending_last_two_weeks__test_trending_last_two_weeks.json
+++ b/backend/tests/snapshots/main__trending_last_two_weeks__test_trending_last_two_weeks.json
@@ -2,7 +2,25 @@
   "hits": [
     {
       "name": "Maze",
-      "keywords": ["maze", "puzzle", "game"],
+      "keywords": [
+        "maze",
+        "puzzle",
+        "game"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "A simple maze game",
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,
@@ -33,6 +53,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +75,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -64,6 +87,7 @@
     {
       "name": "AnyDesk",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "Connect to a computer remotely",
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,

--- a/backend/tests/snapshots/main__trending_last_two_weeks_locale__test_trending_last_two_weeks_locale.json
+++ b/backend/tests/snapshots/main__trending_last_two_weeks_locale__test_trending_last_two_weeks_locale.json
@@ -2,9 +2,27 @@
   "hits": [
     {
       "name": "Laberinto",
-      "keywords": ["laberinto", "rompecabezas", "juego"],
+      "keywords": [
+        "laberinto",
+        "rompecabezas",
+        "juego"
+      ],
+      "localized_keywords": [
+        "Labyrinth",
+        "Rätsel",
+        "Spiel",
+        "casse-tête",
+        "game",
+        "jeu",
+        "juego",
+        "laberinto",
+        "labyrinthe",
+        "maze",
+        "puzzle",
+        "rompecabezas"
+      ],
       "summary": "Un simple juego de laberintos",
-      "description": "\u00bfEres bueno encontrando la salida de situaciones dif\u00edciles?",
+      "description": "¿Eres bueno encontrando la salida de situaciones difíciles?",
       "id": "org_sugarlabs_Maze",
       "type": "desktop-application",
       "project_license": "GPL-3.0-or-later",
@@ -23,7 +41,9 @@
       "verification_timestamp": null,
       "runtime": "org.gnome.Platform/x86_64/3.36",
       "updated_at": 1610973680,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973680,
       "trending": 5.0,
       "installs_last_month": 509,
@@ -33,6 +53,7 @@
     {
       "name": "WPS Office",
       "keywords": null,
+      "localized_keywords": null,
       "summary": "WPS Office Suite",
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
@@ -54,7 +75,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973768,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973768,
       "trending": 15.150000000000034,
       "installs_last_month": 1151,
@@ -64,8 +87,9 @@
     {
       "name": "AnyDesk",
       "keywords": null,
-      "summary": "Con\u00e9ctese a un ordenador de forma remota",
-      "description": "Gracias a AnyDesk, contar\u00e1 con conexiones seguras y fiables de escritorio remoto para profesionales inform\u00e1ticos y usuarios en movimiento.",
+      "localized_keywords": null,
+      "summary": "Conéctese a un ordenador de forma remota",
+      "description": "Gracias a AnyDesk, contará con conexiones seguras y fiables de escritorio remoto para profesionales informáticos y usuarios en movimiento.",
       "id": "com_anydesk_Anydesk",
       "type": "desktop-application",
       "project_license": "LicenseRef-proprietary",
@@ -84,7 +108,9 @@
       "verification_timestamp": null,
       "runtime": "org.freedesktop.Platform/x86_64/20.08",
       "updated_at": 1610973790,
-      "arches": ["x86_64"],
+      "arches": [
+        "x86_64"
+      ],
       "added_at": 1610973790,
       "trending": 13.650000000000034,
       "installs_last_month": 653,


### PR DESCRIPTION
Localized tag links (e.g. Arabic فيلم) generated on non-English app pages were returning 404 because the /collection/keyword endpoint only filtered against the top-level English keywords field in Meilisearch.

Introduce a localized_keywords field in the search index that aggregates keywords from all locales (English + all translations) into a single flat array. Make this field filterable and use it in get_by_keyword so that tag collection pages work for keywords in any language.

Fixes #6406