### PR TITLE
fix: provide explicit width/height attrs on screenshot imgs in OG ima…

### DIFF
--- a/frontend/app/api/appOgImage/[appId]/route.tsx
+++ b/frontend/app/api/appOgImage/[appId]/route.tsx
@@ -141,6 +141,8 @@ export async function GET(
           screenshot.height &&
           screenshot.width > screenshot.height && (
             <img
+              width={screenshot.width}
+              height={screenshot.height}
               style={{
                 display: "flex",
                 width: "620px",
@@ -155,6 +157,8 @@ export async function GET(
           screenshot.height &&
           screenshot.width < screenshot.height && (
             <img
+              width={screenshot.width}
+              height={screenshot.height}
               style={{
                 display: "flex",
                 height: "420px",


### PR DESCRIPTION
…ge route

Satori cannot determine image dimensions from CSS styles alone and throws an error when width/height attributes are absent. Pass the dimensions from the appstream screenshot data as HTML attributes so satori can compute the correct aspect ratio.