### PR TITLE
seo: add canonical URLs to static pages and improve homepage metadata

### DIFF
--- a/frontend/app/[locale]/(home)/page.tsx
+++ b/frontend/app/[locale]/(home)/page.tsx
@@ -20,9 +20,10 @@ import {
 } from "../../../src/codegen"
 import { formatISO } from "date-fns"
 import HomeClient from "../home-client"
-import { setRequestLocale } from "next-intl/server"
+import { getTranslations, setRequestLocale } from "next-intl/server"
 import { staticLocales } from "../../../src/i18n/static-locales"
 import { gameCategoryFilter } from "../../../src/types/Category"
+import cardImage from "../../../public/img/card.webp"
 
 const categoryOrder = [
   MainCategory.office,
@@ -51,10 +52,32 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>
 }): Promise<Metadata> {
   const { locale } = await params
+  const t = await getTranslations({ locale })
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_BASE_URI || "https://flathub.org"
 
   return {
+    title: t("flathub-apps-for-linux"),
+    description: t("flathub-description"),
+    openGraph: {
+      title: t("flathub-apps-for-linux"),
+      description: t("flathub-description"),
+      url: `${siteUrl}/${locale}`,
+      images: [
+        {
+          url: cardImage.src,
+          width: cardImage.width,
+          height: cardImage.height,
+          alt: t("flathub-apps-for-linux"),
+        },
+      ],
+    },
+    twitter: {
+      title: t("flathub-apps-for-linux"),
+      description: t("flathub-description"),
+      images: [cardImage.src],
+    },
     alternates: {
-      canonical: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/${locale}`,
+      canonical: `${siteUrl}/${locale}`,
     },
   }
 }

--- a/frontend/app/[locale]/about/page.tsx
+++ b/frontend/app/[locale]/about/page.tsx
@@ -15,6 +15,9 @@ export async function generateMetadata({
   return {
     title: t("about-pagename"),
     description: t("about-description"),
+    alternates: {
+      canonical: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/${locale}/about`,
+    },
   }
 }
 

--- a/frontend/app/[locale]/setup/page.tsx
+++ b/frontend/app/[locale]/setup/page.tsx
@@ -21,6 +21,9 @@ export async function generateMetadata({
   return {
     title: t("setup-flathub"),
     description: t("setup-flathub-description"),
+    alternates: {
+      canonical: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/${locale}/setup`,
+    },
   }
 }
 

--- a/frontend/app/[locale]/statistics/page.tsx
+++ b/frontend/app/[locale]/statistics/page.tsx
@@ -20,6 +20,9 @@ export async function generateMetadata({
   return {
     title: t("statistics"),
     description: t("flathub-statistics-description"),
+    alternates: {
+      canonical: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/${locale}/statistics`,
+    },
   }
 }
 


### PR DESCRIPTION
- Add alternates.canonical to the about, statistics, and setup pages which had title/description but no canonical signal
- Improve homepage generateMetadata: add explicit title, description, OG image with dimensions, and Twitter card tags instead of falling through to layout defaults with only a canonical URL