### PR TITLE
seo: add BreadcrumbList, FAQPage, and WebSite JSON-LD structured data

### DIFF
--- a/frontend/app/[locale]/apps/[appId]/app-detail-client.tsx
+++ b/frontend/app/[locale]/apps/[appId]/app-detail-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { SoftwareAppJsonLd, VideoGameJsonLd } from "next-seo"
+import { BreadcrumbJsonLd, SoftwareAppJsonLd, VideoGameJsonLd } from "next-seo"
 import { useState } from "react"
 import { useTranslations } from "next-intl"
 import ApplicationDetails from "../../../../src/components/application/Details"
@@ -11,6 +11,10 @@ import { calculateHumanReadableSize } from "../../../../src/size"
 import { bcpToPosixLocale } from "../../../../src/localize"
 import { getContentRating } from "../../../../src/contentRating"
 import { findBiggestScreenshotSize } from "../../../../src/types/Appstream"
+import {
+  stringToCategory,
+  categoryToName,
+} from "../../../../src/types/Category"
 import type { JSX } from "react"
 import type { Summary } from "../../../../src/types/Summary"
 import type {
@@ -116,8 +120,50 @@ const AppDetailClient = ({
   const contentRating = getContentRating(app, locale)
   const contentRatingText = contentRating?.minimumAgeText ?? undefined
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_BASE_URI || "https://flathub.org"
+
+  // Derive a breadcrumb category from the app's categories list
+  const firstCategory =
+    isDesktopAppstreamTypeGuard(app) && Array.isArray(app.categories)
+      ? stringToCategory(app.categories[0])
+      : undefined
+  const categoryLabel = firstCategory
+    ? categoryToName(firstCategory, t)
+    : undefined
+  const categorySlug = firstCategory?.toLowerCase()
+
   return (
     <>
+      <BreadcrumbJsonLd
+        useAppDir={true}
+        itemListElements={[
+          {
+            position: 1,
+            name: t("home"),
+            item: siteUrl,
+          },
+          ...(categoryLabel && categorySlug
+            ? [
+                {
+                  position: 2,
+                  name: categoryLabel,
+                  item: `${siteUrl}/apps/category/${categorySlug}`,
+                },
+                {
+                  position: 3,
+                  name: app.name,
+                  item: `${siteUrl}/apps/${app.id}`,
+                },
+              ]
+            : [
+                {
+                  position: 2,
+                  name: app.name,
+                  item: `${siteUrl}/apps/${app.id}`,
+                },
+              ]),
+        ]}
+      />
       {isDesktopAppstreamTypeGuard(app) && (
         <QualityModeration
           app={app}

--- a/frontend/app/[locale]/setup/page.tsx
+++ b/frontend/app/[locale]/setup/page.tsx
@@ -24,6 +24,61 @@ export async function generateMetadata({
   }
 }
 
+const setupFaqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "What is Flatpak?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Flatpak is a universal packaging format for Linux desktop applications. It lets developers distribute apps that work across all major Linux distributions without modification.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I install Flatpak on Ubuntu?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "To install Flatpak on Ubuntu, run: sudo apt install flatpak. Then add the Flathub repository with: flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo. Restart your system to complete the setup.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I install Flatpak on Fedora?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Flatpak is installed by default on Fedora. To add the Flathub app store, run: flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How do I install a Flatpak app from Flathub?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Once Flathub is set up, install any app using: flatpak install flathub APP_ID. For example: flatpak install flathub org.mozilla.firefox. You can also install apps directly from the Flathub website by clicking the Install button.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is Flathub free to use?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes, Flathub is free to use. The majority of apps on Flathub are free and open source software. Some apps may offer optional donations or paid features.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Which Linux distributions support Flatpak?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Flatpak is supported on virtually all major Linux distributions including Ubuntu, Fedora, Debian, Arch Linux, Linux Mint, openSUSE, Manjaro, Pop!_OS, elementary OS, and many more.",
+      },
+    },
+  ],
+}
+
 export default async function SetupPage({
   params,
 }: {
@@ -40,5 +95,13 @@ export default async function SetupPage({
     notFound()
   }
 
-  return <SetupClient instructions={instructions} />
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(setupFaqJsonLd) }}
+      />
+      <SetupClient instructions={instructions} />
+    </>
+  )
 }


### PR DESCRIPTION
- App detail pages: emit BreadcrumbJsonLd with a category-aware path (Home → Category → App Name) to enable rich breadcrumbs in search results
- Setup page: add a FAQPage JSON-LD script covering common Flatpak/Flathub setup questions to target featured snippet positions
