### PR TITLE
seo: fix expired security.txt, add /setup to sitemap, RSS autodiscove…

### DIFF
--- a/frontend/app/[locale]/apps/[appId]/app-detail-client.tsx
+++ b/frontend/app/[locale]/apps/[appId]/app-detail-client.tsx
@@ -86,12 +86,7 @@ const AppDetailClient = ({
   const [isQualityModalOpen, setIsQualityModalOpen] = useState(false)
 
   if (eolMessage) {
-    return (
-      <>
-        {/* <meta name="robots" content="noindex" /> */}
-        <EolMessageDetails message={eolMessage} />
-      </>
-    )
+    return <EolMessageDetails message={eolMessage} />
   }
 
   if (!app) {

--- a/frontend/app/[locale]/apps/[appId]/page.tsx
+++ b/frontend/app/[locale]/apps/[appId]/page.tsx
@@ -44,15 +44,19 @@ export async function generateMetadata({
   const t = await getTranslations({ locale })
 
   try {
-    const response = await getAppstreamAppstreamAppIdGet(appId, { locale })
+    const [response, eolMessageResponse] = await Promise.all([
+      getAppstreamAppstreamAppIdGet(appId, { locale }),
+      getEolMessageAppidEolMessageAppIdGet(appId).catch(() => ({ data: null })),
+    ])
     const app = response.data
+    const isEol = !!eolMessageResponse.data
 
     return {
       title: t("install-x", { app_name: app?.name }),
       description: app?.summary,
       authors: app?.developer_name ? [{ name: app.developer_name }] : undefined,
       robots: {
-        index: app.type !== "addon" && locale !== "en-GB",
+        index: app.type !== "addon" && locale !== "en-GB" && !isEol,
       },
       openGraph: {
         url: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/${locale}/apps/${app?.id}`,

--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -98,6 +98,18 @@ export default async function LocaleLayout({
         <link rel="preconnect" href="https://dl.flathub.org" />
         <link rel="preconnect" href="https://webstats.gnome.org" />
         <link rel="preconnect" href="https://imgproxy.flathub.org" />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Flathub – New Apps"
+          href="/feed/new"
+        />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Flathub – Recently Updated Apps"
+          href="/feed/recently-updated"
+        />
       </head>
       <body className={inter.className}>
         <NextIntlClientProvider>

--- a/frontend/app/sitemap-utils.ts
+++ b/frontend/app/sitemap-utils.ts
@@ -12,6 +12,7 @@ export const staticPages = [
   "",
   "/about",
   "/statistics",
+  "/setup",
   "/languages",
   "/consultants",
   "/badges",

--- a/frontend/public/.well-known/security.txt
+++ b/frontend/public/.well-known/security.txt
@@ -1,4 +1,4 @@
 Contact: mailto:admins@flathub.org
-Expires: 2025-12-30T23:00:00.000Z
+Expires: 2026-12-31T23:00:00.000Z
 Preferred-Languages: en
 Canonical: https://flathub.org/.well-known/security.txt


### PR DESCRIPTION
…ry, noindex EOL apps

- Renew security.txt expiry (2025-12-30 → 2026-12-31)
- Add /setup to the sitemap static pages list so distro setup instructions are crawlable
- Add RSS autodiscovery <link> tags to the root layout for the new-apps and recently-updated feeds
- Noindex EOL app pages by fetching the EOL message in generateMetadata and setting robots.index: false; remove stale commented-out client-side meta tag