### PR TITLE
fix: avoid replica lag in quality moderation sideblade

### DIFF
--- a/backend/app/routes/quality_moderation.py
+++ b/backend/app/routes/quality_moderation.py
@@ -342,6 +342,7 @@ def request_review_for_app(
         if app and app.excluded_from_app_picks:
             raise HTTPException(status_code=404, detail="App excluded from app picks")
         QualityModerationRequest.create(db, app_id, moderator.user.id)
+        return QualityModeration.by_appid_summarized(db, app_id)
 
 
 @router.delete(

--- a/backend/app/routes/quality_moderation.py
+++ b/backend/app/routes/quality_moderation.py
@@ -239,7 +239,7 @@ def set_quality_moderation_for_app(
         examples=["org.gnome.Glade"],
     ),
     moderator=Depends(quality_moderator_only),
-):
+) -> QualityModerationResponse:
     with get_db("writer") as db:
         app = App.by_appid(db, app_id)
         if app and app.excluded_from_app_picks:
@@ -247,6 +247,43 @@ def set_quality_moderation_for_app(
         QualityModeration.upsert(
             db, app_id, body.guideline_id, body.passed, moderator.user.id
         )
+
+        items = [
+            QualityModerationType(
+                guideline_id=guideline.id,
+                app_id=app_id,
+                updated_at=(
+                    quality_moderation.updated_at
+                    if quality_moderation
+                    else datetime.datetime.min
+                ),
+                updated_by=(
+                    quality_moderation.updated_by if quality_moderation else None
+                ),
+                passed=(quality_moderation.passed if quality_moderation else None),
+                comment=(quality_moderation.comment if quality_moderation else None),
+                guideline=Guideline(
+                    id=guideline.id,
+                    url=guideline.url,
+                    needed_to_pass_since=guideline.needed_to_pass_since,
+                    read_only=guideline.read_only,
+                    category=guideline.guideline_category_id,
+                ),
+                needed_to_pass_since=guideline.needed_to_pass_since,
+            )
+            for guideline, quality_moderation, app in QualityModeration.by_appid(
+                db, app_id
+            )
+        ]
+
+        review_request = QualityModerationRequest.by_appid(db, app_id)
+        is_fullscreen_app = App.get_fullscreen_app(db, app_id)
+
+    return QualityModerationResponse(
+        guidelines=items,
+        is_fullscreen_app=is_fullscreen_app,
+        review_requested_at=review_request.created_at if review_request else None,
+    )
 
 
 @router.get(

--- a/backend/app/routes/quality_moderation.py
+++ b/backend/app/routes/quality_moderation.py
@@ -364,12 +364,49 @@ def delete_review_request_for_app(
         examples=["org.gnome.Glade"],
     ),
     _moderator=Depends(quality_moderator_only),
-):
+) -> QualityModerationResponse:
     with get_db("writer") as db:
         app = App.by_appid(db, app_id)
         if app and app.excluded_from_app_picks:
             raise HTTPException(status_code=404, detail="App excluded from app picks")
         QualityModerationRequest.delete(db, app_id)
+
+        items = [
+            QualityModerationType(
+                guideline_id=guideline.id,
+                app_id=app_id,
+                updated_at=(
+                    quality_moderation.updated_at
+                    if quality_moderation
+                    else datetime.datetime.min
+                ),
+                updated_by=(
+                    quality_moderation.updated_by if quality_moderation else None
+                ),
+                passed=(quality_moderation.passed if quality_moderation else None),
+                comment=(quality_moderation.comment if quality_moderation else None),
+                guideline=Guideline(
+                    id=guideline.id,
+                    url=guideline.url,
+                    needed_to_pass_since=guideline.needed_to_pass_since,
+                    read_only=guideline.read_only,
+                    category=guideline.guideline_category_id,
+                ),
+                needed_to_pass_since=guideline.needed_to_pass_since,
+            )
+            for guideline, quality_moderation, app in QualityModeration.by_appid(
+                db, app_id
+            )
+        ]
+
+        review_request = QualityModerationRequest.by_appid(db, app_id)
+        is_fullscreen_app = App.get_fullscreen_app(db, app_id)
+
+    return QualityModerationResponse(
+        guidelines=items,
+        is_fullscreen_app=is_fullscreen_app,
+        review_requested_at=review_request.created_at if review_request else None,
+    )
 
 
 @router.post(
@@ -393,9 +430,46 @@ def set_fullscreen_app(
         examples=["org.gnome.Glade"],
     ),
     moderator=Depends(quality_moderator_only),
-):
+) -> QualityModerationResponse:
     with get_db("writer") as db:
         app = App.by_appid(db, app_id)
         if app and app.excluded_from_app_picks:
             raise HTTPException(status_code=404, detail="App excluded from app picks")
         App.set_fullscreen_app(db, app_id, is_fullscreen_app)
+
+        items = [
+            QualityModerationType(
+                guideline_id=guideline.id,
+                app_id=app_id,
+                updated_at=(
+                    quality_moderation.updated_at
+                    if quality_moderation
+                    else datetime.datetime.min
+                ),
+                updated_by=(
+                    quality_moderation.updated_by if quality_moderation else None
+                ),
+                passed=(quality_moderation.passed if quality_moderation else None),
+                comment=(quality_moderation.comment if quality_moderation else None),
+                guideline=Guideline(
+                    id=guideline.id,
+                    url=guideline.url,
+                    needed_to_pass_since=guideline.needed_to_pass_since,
+                    read_only=guideline.read_only,
+                    category=guideline.guideline_category_id,
+                ),
+                needed_to_pass_since=guideline.needed_to_pass_since,
+            )
+            for guideline, quality_moderation, app in QualityModeration.by_appid(
+                db, app_id
+            )
+        ]
+
+        review_request = QualityModerationRequest.by_appid(db, app_id)
+        fullscreen = App.get_fullscreen_app(db, app_id)
+
+    return QualityModerationResponse(
+        guidelines=items,
+        is_fullscreen_app=fullscreen,
+        review_requested_at=review_request.created_at if review_request else None,
+    )

--- a/frontend/src/codegen/quality-moderation/quality-moderation.ts
+++ b/frontend/src/codegen/quality-moderation/quality-moderation.ts
@@ -1211,7 +1211,7 @@ export const setQualityModerationForAppQualityModerationAppIdPost = (
   appId: string,
   upsertQualityModeration: UpsertQualityModeration,
   options?: AxiosRequestConfig,
-): Promise<AxiosResponse<unknown>> => {
+): Promise<AxiosResponse<QualityModerationResponse>> => {
   return axios.post(
     `/quality-moderation/${appId}`,
     upsertQualityModeration,

--- a/frontend/src/codegen/quality-moderation/quality-moderation.ts
+++ b/frontend/src/codegen/quality-moderation/quality-moderation.ts
@@ -1561,7 +1561,7 @@ export function useGetQualityModerationStatusForAppQualityModerationAppIdStatusG
 export const requestReviewForAppQualityModerationAppIdRequestReviewPost = (
   appId: string,
   options?: AxiosRequestConfig,
-): Promise<AxiosResponse<unknown>> => {
+): Promise<AxiosResponse<QualityModerationStatus>> => {
   return axios.post(
     `/quality-moderation/${appId}/request-review`,
     undefined,

--- a/frontend/src/codegen/quality-moderation/quality-moderation.ts
+++ b/frontend/src/codegen/quality-moderation/quality-moderation.ts
@@ -1679,7 +1679,7 @@ export const deleteReviewRequestForAppQualityModerationAppIdRequestReviewDelete 
   (
     appId: string,
     options?: AxiosRequestConfig,
-  ): Promise<AxiosResponse<unknown | void>> => {
+  ): Promise<AxiosResponse<QualityModerationResponse>> => {
     return axios.delete(`/quality-moderation/${appId}/request-review`, options)
   }
 
@@ -1791,7 +1791,7 @@ export const setFullscreenAppQualityModerationAppIdFullscreenPost = (
   appId: string,
   params: SetFullscreenAppQualityModerationAppIdFullscreenPostParams,
   options?: AxiosRequestConfig,
-): Promise<AxiosResponse<unknown>> => {
+): Promise<AxiosResponse<QualityModerationResponse>> => {
   return axios.post(`/quality-moderation/${appId}/fullscreen`, undefined, {
     ...options,
     params: { ...params, ...options?.params },

--- a/frontend/src/components/application/QualityModeration.tsx
+++ b/frontend/src/components/application/QualityModeration.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 import { useUserContext } from "src/context/user-info"
 import { QualityModerationSlideOver } from "./QualityModerationSlideOver"
 import Spinner from "../Spinner"
@@ -71,24 +72,26 @@ const QualityReviewButton = ({
   review_requested_at,
   status,
   app_id,
-  buttonClicked,
   mode,
 }: {
   review_requested_at?: string
   status?: QualityModerationStatus
   app_id: string
-  buttonClicked?: () => void
   mode?: "qualityModerator" | "developer"
 }) => {
   const t = useTranslations()
+  const queryClient = useQueryClient()
 
   const [modalVisible, setModalVisible] = useState(false)
 
   const requestReviewMutation =
     useRequestReviewForAppQualityModerationAppIdRequestReviewPost({
       mutation: {
-        onSuccess: () => {
-          buttonClicked?.()
+        onSuccess: (data) => {
+          queryClient.setQueryData(
+            [`/quality-moderation/${app_id}/status`],
+            data,
+          )
           setModalVisible(false)
         },
       },
@@ -279,9 +282,6 @@ export const QualityModeration = ({
               app_id={app.id}
               status={query?.data?.data}
               review_requested_at={query?.data?.data?.review_requested_at}
-              buttonClicked={() => {
-                query.refetch()
-              }}
               mode={mode}
             />
           )}

--- a/frontend/src/components/application/QualityModerationSlideOver.tsx
+++ b/frontend/src/components/application/QualityModerationSlideOver.tsx
@@ -295,8 +295,8 @@ const QualityCategories = ({
           withCredentials: true,
         },
       ),
-    onSuccess: () => {
-      query.refetch()
+    onSuccess: (data) => {
+      queryClient.setQueryData(["qualityModeration", { appId: app.id }], data)
     },
   })
 
@@ -526,6 +526,8 @@ const ScreenShotTypeItem = ({
     setToggle(is_fullscreen_app)
   }, [is_fullscreen_app])
 
+  const queryClient = useQueryClient()
+
   const mutation = useMutation({
     mutationFn: ({ is_fullscreen_app }: { is_fullscreen_app: boolean }) =>
       setFullscreenAppQualityModerationAppIdFullscreenPost(
@@ -536,9 +538,9 @@ const ScreenShotTypeItem = ({
         },
       ),
 
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
       setToggle(variables.is_fullscreen_app)
-      query.refetch()
+      queryClient.setQueryData(["qualityModeration", { appId }], data)
     },
   })
 

--- a/frontend/src/components/application/QualityModerationSlideOver.tsx
+++ b/frontend/src/components/application/QualityModerationSlideOver.tsx
@@ -1,4 +1,9 @@
-import { UseQueryResult, useMutation, useQuery } from "@tanstack/react-query"
+import {
+  UseQueryResult,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import Spinner from "../Spinner"
 import clsx from "clsx"
 import { useEffect, useState } from "react"
@@ -253,6 +258,8 @@ const QualityCategories = ({
 }) => {
   const t = useTranslations()
 
+  const queryClient = useQueryClient()
+
   const passAllMutation = useMutation({
     mutationFn: () => {
       return Promise.all(
@@ -270,8 +277,13 @@ const QualityCategories = ({
       )
     },
 
-    onSuccess: (_data, variables) => {
-      query.refetch()
+    onSuccess: (data) => {
+      if (data.length > 0) {
+        queryClient.setQueryData(
+          ["qualityModeration", { appId: app.id }],
+          data[data.length - 1],
+        )
+      }
     },
   })
 
@@ -420,6 +432,8 @@ const QualityItem = ({
     setToggle(qualityModeration?.passed)
   }, [qualityModeration])
 
+  const queryClient = useQueryClient()
+
   const mutation = useMutation({
     mutationFn: ({ passed }: { passed: boolean }) =>
       setQualityModerationForAppQualityModerationAppIdPost(
@@ -430,9 +444,9 @@ const QualityItem = ({
         },
       ),
 
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
       setToggle(variables.passed)
-      query.refetch()
+      queryClient.setQueryData(["qualityModeration", { appId }], data)
     },
   })
 


### PR DESCRIPTION
POST endpoint now returns the full QualityModerationResponse read from
the writer DB, so the frontend can update the query cache directly from
the mutation response instead of refetching from the replica.