### PR TITLE
feat: surface OS and Flatpak version stats from daily JSON

### DIFF
--- a/backend/app/routes/stats.py
+++ b/backend/app/routes/stats.py
@@ -34,6 +34,7 @@ class StatsResult(BaseModel):
     category_totals: list[StatsResultCategoryTotals]
     os_versions: dict[str, int]
     flatpak_versions: dict[str, int]
+    os_flatpak_versions: dict[str, dict[str, int]]
 
 
 class StatsResultApp(BaseModel):

--- a/backend/app/routes/stats.py
+++ b/backend/app/routes/stats.py
@@ -32,6 +32,8 @@ class StatsResult(BaseModel):
     updates_per_day: dict[str, int]
     delta_downloads_per_day: dict[str, int]
     category_totals: list[StatsResultCategoryTotals]
+    os_versions: dict[str, int]
+    flatpak_versions: dict[str, int]
 
 
 class StatsResultApp(BaseModel):

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -159,6 +159,7 @@ def _init_empty_aggregates() -> dict:
             "totals_country": {},
             "totals_os_versions": {},
             "totals_flatpak_versions": {},
+            "totals_os_flatpak_versions": {},
         },
         "last_date": None,
     }
@@ -212,6 +213,11 @@ def _update_global_stats_for_date(
             global_dict["totals_flatpak_versions"][fp_ver] = (
                 global_dict["totals_flatpak_versions"].get(fp_ver, 0) + count
             )
+    if stats.get("os_flatpak_versions"):
+        for os_ver, fp_versions in stats["os_flatpak_versions"].items():
+            os_entry = global_dict["totals_os_flatpak_versions"].setdefault(os_ver, {})
+            for fp_ver, count in fp_versions.items():
+                os_entry[fp_ver] = os_entry.get(fp_ver, 0) + count
 
 
 def _update_aggregates_for_date(date: datetime.date, stats: dict, agg: dict) -> None:
@@ -578,6 +584,9 @@ def _build_stats_dict_from_aggregates(agg: dict, app_count: int) -> dict:
         "totals_flatpak_versions": dict(
             agg["global"].get("totals_flatpak_versions", {})
         ),
+        "totals_os_flatpak_versions": dict(
+            agg["global"].get("totals_os_flatpak_versions", {})
+        ),
     }
 
     edate = datetime.date.today()
@@ -602,6 +611,7 @@ def _build_stats_dict_from_aggregates(agg: dict, app_count: int) -> dict:
         "category_totals": category_totals,
         "os_versions": global_dict["totals_os_versions"],
         "flatpak_versions": global_dict["totals_flatpak_versions"],
+        "os_flatpak_versions": global_dict["totals_os_flatpak_versions"],
     }
 
 
@@ -801,6 +811,18 @@ def update(sqldb):
                     stats_apps_dict[new_id]["installs_per_country"][country] += count
                 else:
                     stats_apps_dict[new_id]["installs_per_country"][country] = count
+
+            for os_version, count in stats_apps_dict[old_id][
+                "installs_per_os_version"
+            ].items():
+                if os_version in stats_apps_dict[new_id]["installs_per_os_version"]:
+                    stats_apps_dict[new_id]["installs_per_os_version"][os_version] += (
+                        count
+                    )
+                else:
+                    stats_apps_dict[new_id]["installs_per_os_version"][os_version] = (
+                        count
+                    )
 
     redis_conn.set("stats", orjson.dumps(stats_dict))
     database.bulk_set_app_stats(stats_apps_dict)

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -25,8 +25,11 @@ class StatsFromServer(TypedDict):
     downloads: int
     updates: int
     flatpak_versions: dict[str, int]
+    os_flatpak_versions: dict[str, dict[str, int]]
+    os_versions: dict[str, int]
     ostree_versions: dict[str, int]
     ref_by_country: dict[str, dict[str, list[int]]]
+    ref_by_os_version: dict[str, dict[str, list[int]]]
     refs: dict[str, dict[str, list[int]]]
 
 
@@ -36,6 +39,7 @@ AGGREGATES_KEYS = {
     "totals": "stats:agg:totals",
     "per_day": "stats:agg:per_day",
     "per_country": "stats:agg:per_country",
+    "per_os_version": "stats:agg:per_os_version",
     "global": "stats:agg:global",
     "last_date": "stats:agg:last_date",
 }
@@ -147,14 +151,35 @@ def _init_empty_aggregates() -> dict:
         "totals": {},
         "per_day": {},
         "per_country": {},
+        "per_os_version": {},
         "global": {
             "downloads_per_day": {},
             "updates_per_day": {},
             "delta_downloads_per_day": {},
             "totals_country": {},
+            "totals_os_versions": {},
+            "totals_flatpak_versions": {},
         },
         "last_date": None,
     }
+
+
+def _normalize_aggregates(agg: dict) -> dict:
+    normalized = _init_empty_aggregates()
+
+    for key in ("totals", "per_day", "per_country", "per_os_version"):
+        if isinstance(agg.get(key), dict):
+            normalized[key] = agg[key]
+
+    if isinstance(agg.get("global"), dict):
+        for key in normalized["global"]:
+            if isinstance(agg["global"].get(key), dict):
+                normalized["global"][key] = agg["global"][key]
+
+    if agg.get("last_date") is not None:
+        normalized["last_date"] = agg["last_date"]
+
+    return normalized
 
 
 def _update_global_stats_for_date(
@@ -176,6 +201,16 @@ def _update_global_stats_for_date(
         for country, downloads in stats["countries"].items():
             global_dict["totals_country"][country] = (
                 global_dict["totals_country"].get(country, 0) + downloads
+            )
+    if stats.get("os_versions"):
+        for os_ver, count in stats["os_versions"].items():
+            global_dict["totals_os_versions"][os_ver] = (
+                global_dict["totals_os_versions"].get(os_ver, 0) + count
+            )
+    if stats.get("flatpak_versions"):
+        for fp_ver, count in stats["flatpak_versions"].items():
+            global_dict["totals_flatpak_versions"][fp_ver] = (
+                global_dict["totals_flatpak_versions"].get(fp_ver, 0) + count
             )
 
 
@@ -204,6 +239,14 @@ def _update_aggregates_for_date(date: datetime.date, stats: dict, agg: dict) -> 
             for country, downloads in country_stats.items():
                 country_for_app[country] = (
                     country_for_app.get(country, 0) + downloads[0] - downloads[1]
+                )
+
+    if stats.get("ref_by_os_version"):
+        for app_id, os_stats in stats["ref_by_os_version"].items():
+            os_for_app = agg["per_os_version"].setdefault(app_id, {})
+            for os_ver, downloads in os_stats.items():
+                os_for_app[os_ver] = (
+                    os_for_app.get(os_ver, 0) + downloads[0] - downloads[1]
                 )
 
     _update_global_stats_for_date(date, stats, agg["global"])
@@ -495,7 +538,7 @@ def _build_or_update_aggregates() -> dict:
     if config.settings.force_recompute_stats:
         _delete_aggregates()
 
-    agg = _load_aggregates()
+    agg = _normalize_aggregates(_load_aggregates())
 
     if agg["last_date"] is None:
         agg = _init_empty_aggregates()
@@ -531,6 +574,10 @@ def _build_stats_dict_from_aggregates(agg: dict, app_count: int) -> dict:
         "updates_per_day": dict(agg["global"]["updates_per_day"]),
         "delta_downloads_per_day": dict(agg["global"]["delta_downloads_per_day"]),
         "totals_country": dict(agg["global"]["totals_country"]),
+        "totals_os_versions": dict(agg["global"].get("totals_os_versions", {})),
+        "totals_flatpak_versions": dict(
+            agg["global"].get("totals_flatpak_versions", {})
+        ),
     }
 
     edate = datetime.date.today()
@@ -553,6 +600,8 @@ def _build_stats_dict_from_aggregates(agg: dict, app_count: int) -> dict:
         "updates_per_day": global_dict["updates_per_day"],
         "delta_downloads_per_day": global_dict["delta_downloads_per_day"],
         "category_totals": category_totals,
+        "os_versions": global_dict["totals_os_versions"],
+        "flatpak_versions": global_dict["totals_flatpak_versions"],
     }
 
 
@@ -628,6 +677,11 @@ def update(sqldb):
         if app_id in agg["per_country"]:
             stats_apps_dict[app_id]["installs_per_country"] = agg["per_country"][app_id]
 
+        if app_id in agg["per_os_version"]:
+            stats_apps_dict[app_id]["installs_per_os_version"] = agg["per_os_version"][
+                app_id
+            ]
+
     recent_sdate = edate - datetime.timedelta(days=1)
     recent_stats = _get_stats_for_period(recent_sdate, edate)
     for app_id, app_dict in recent_stats.items():
@@ -696,6 +750,9 @@ def update(sqldb):
         stats_apps_dict[app_id]["installs_per_country"] = stats_apps_dict[app_id].get(
             "installs_per_country", {}
         )
+        stats_apps_dict[app_id]["installs_per_os_version"] = stats_apps_dict[
+            app_id
+        ].get("installs_per_os_version", {})
 
     new_id: str
     old_id_list: list[str]
@@ -707,6 +764,7 @@ def update(sqldb):
                 "installs_last_7_days": 0,
                 "installs_per_day": {},
                 "installs_per_country": {},
+                "installs_per_os_version": {},
             }
 
         for old_id in old_id_list:

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -5,6 +5,7 @@ import time
 from urllib import parse
 
 import gi
+import orjson
 import pytest
 import vcr
 from fastapi.testclient import TestClient
@@ -98,6 +99,40 @@ def test_update(client):
     update_stats = client.post("/update/stats")
     assert update_stats.status_code == 200
     time.sleep(10)
+
+
+def test_build_or_update_aggregates_normalizes_old_cache(monkeypatch):
+    from app.worker import update_stats as update_stats_actor
+
+    stats = update_stats_actor.fn.__globals__["stats"]
+
+    today = datetime.date.today()
+    edate = today - datetime.timedelta(days=2)
+    last_date = edate - datetime.timedelta(days=1)
+
+    old_global = {
+        "downloads_per_day": {},
+        "updates_per_day": {},
+        "delta_downloads_per_day": {},
+        "totals_country": {},
+    }
+
+    stats.redis_conn.set("stats:agg:totals", orjson.dumps({}))
+    stats.redis_conn.set("stats:agg:per_day", orjson.dumps({}))
+    stats.redis_conn.set("stats:agg:per_country", orjson.dumps({}))
+    stats.redis_conn.delete("stats:agg:per_os_version")
+    stats.redis_conn.set("stats:agg:global", orjson.dumps(old_global))
+    stats.redis_conn.set("stats:agg:last_date", orjson.dumps(last_date.isoformat()))
+
+    monkeypatch.setattr(stats, "_get_stats_for_date", lambda date: None)
+
+    agg = stats._build_or_update_aggregates()
+
+    assert agg["per_os_version"] == {}
+    assert agg["global"]["totals_os_versions"] == {}
+    assert agg["global"]["totals_flatpak_versions"] == {}
+    assert agg["last_date"] == edate.isoformat()
+    assert orjson.loads(stats.redis_conn.get("stats:agg:per_os_version")) == {}
 
 
 def test_apps_by_category(client, snapshot):
@@ -936,6 +971,8 @@ def test_stats(client):
             {"category": "Office", "count": 1},
         ],
         "countries": {"DE": 852, "FI": 5572, "NL": 144, "US": 3044},
+        "os_versions": {},
+        "flatpak_versions": {},
         "downloads_per_day": {},
         "delta_downloads_per_day": {},
         "updates_per_day": {},

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -131,6 +131,7 @@ def test_build_or_update_aggregates_normalizes_old_cache(monkeypatch):
     assert agg["per_os_version"] == {}
     assert agg["global"]["totals_os_versions"] == {}
     assert agg["global"]["totals_flatpak_versions"] == {}
+    assert agg["global"]["totals_os_flatpak_versions"] == {}
     assert agg["last_date"] == edate.isoformat()
     assert orjson.loads(stats.redis_conn.get("stats:agg:per_os_version")) == {}
 
@@ -973,6 +974,7 @@ def test_stats(client):
         "countries": {"DE": 852, "FI": 5572, "NL": 144, "US": 3044},
         "os_versions": {},
         "flatpak_versions": {},
+        "os_flatpak_versions": {},
         "downloads_per_day": {},
         "delta_downloads_per_day": {},
         "updates_per_day": {},


### PR DESCRIPTION
The upstream stats JSON has grown three new fields that were not modelled anywhere in the codebase: `os_versions`, `os_flatpak_versions`, and `ref_by_os_version`.  `flatpak_versions` was already in the TypedDict but was not being aggregated or exposed.