### PR TITLE
fix: mark current pagination button

### DIFF
--- a/frontend/src/components/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination.stories.tsx
@@ -64,3 +64,13 @@ export const WithQueryParams: Story = {
     searchParams: mockSearchParams,
   },
 }
+
+export const WithOnClick: Story = {
+  args: {
+    currentPage: 3,
+    pages: [1, 2, 3, 4, 5],
+    onClick: () => undefined,
+    pathname: mockPathname,
+    searchParams: mockSearchParams,
+  },
+}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -61,6 +61,8 @@ const Pagination: FunctionComponent<Props> = ({
 
               {onClick && (
                 <button
+                  type="button"
+                  aria-current={isActive ? "page" : undefined}
                   onClick={() => onClick(curr)}
                   className={clsx(
                     isActive &&


### PR DESCRIPTION
## Summary

- adds `type="button"` to callback-mode pagination buttons
- marks the current callback-mode page with `aria-current="page"`, matching the link-rendered pagination path
- adds a Storybook story for the `onClick` pagination variant

## Test plan

- `git diff --check`