### PR TITLE
Add clickable repo file link to NixOS instructions

### DIFF
--- a/frontend/public/locales/en/distros.json
+++ b/frontend/public/locales/en/distros.json
@@ -289,7 +289,7 @@
     },
     "step-2": {
       "name": "Add the Flathub repository",
-      "text": "<text>Flathub is the best place to get Flatpak apps. To enable it, run:</text> <code></code>"
+      "text": "<text>Flathub is the best place to get Flatpak apps. To enable it, download and install the <filelink>Flathub repository file</filelink> or run:</text> <code></code>"
     },
     "step-3": {
       "name": "Restart",

--- a/frontend/src/components/setup/Distros.tsx
+++ b/frontend/src/components/setup/Distros.tsx
@@ -2167,6 +2167,11 @@ const NixOS = ({ locale }: { locale: string }) => {
                 }
               />
             ),
+            filelink: (chunk) => (
+              <a href="https://dl.flathub.org/repo/flathub.flatpakrepo">
+                {chunk}
+              </a>
+            ),
           })}
         </li>
 

--- a/frontend/src/data/distro.yml
+++ b/frontend/src/data/distro.yml
@@ -334,9 +334,9 @@
         <terminal-command>sudo nixos-rebuild switch</terminal-command>
         <p>For more details see the <a href='https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak'>NixOS documentation</a>.</p>"
     - name: Add the Flathub repository
-      text: "
-        <p>Flathub is the best place to get Flatpak apps. To enable it, run:</p>
-        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>"
+      text: '
+        <p>Flathub is the best place to get Flatpak apps. To enable it, download and install the <a class="btn btn-default" href="https://dl.flathub.org/repo/flathub.flatpakrepo">Flathub repository file</a> or run:</p>
+        <terminal-command>flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo</terminal-command>'
     - name: Restart
       text: '
         <p>To complete setup, restart your system. Now all you have to do is <a href="https://flathub.org/">install apps</a>!</p>'


### PR DESCRIPTION
Just like Ubuntu etc. and also the official [NixOS manual](https://nixos.org/manual/nixos/stable/index.html#module-services-flatpak).