### PR TITLE
Fix backend email rendering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
     schedule:
       interval: "daily"
     groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
       react-email:
         patterns:
           - "@react-email/*"

--- a/.github/workflows/backend_node_ci.yml
+++ b/.github/workflows/backend_node_ci.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-        # 6.0.2
+      # 6.0.2
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
@@ -42,6 +42,9 @@ jobs:
 
       - name: Format
         run: pnpm format
+
+      - name: Test
+        run: pnpm test
 
       - name: Build application
         run: pnpm build

--- a/backend-node/package.json
+++ b/backend-node/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "test": "tsx --test src/**/*.test.ts",
     "build": "tsc",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
@@ -20,7 +21,7 @@
     "hono": "^4.12.31",
     "nodemailer": "9.0.3",
     "react": "19.2.8",
-    "react-dom": "19.2.7",
+    "react-dom": "19.2.8",
     "react-email": "6.9.0",
     "zod": "^4.4.3"
   },

--- a/backend-node/pnpm-lock.yaml
+++ b/backend-node/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.5.1(hono@4.12.31)(zod@4.4.3)
       '@react-email/render':
         specifier: 2.1.0
-        version: 2.1.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+        version: 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@react-email/tailwind':
         specifier: ^2.0.7
         version: 2.0.7(@react-email/body@0.3.0(react@19.2.8))(@react-email/button@0.2.1(react@19.2.8))(@react-email/code-block@0.2.1(react@19.2.8))(@react-email/code-inline@0.0.6(react@19.2.8))(@react-email/container@0.0.16(react@19.2.8))(@react-email/heading@0.0.16(react@19.2.8))(@react-email/hr@0.0.12(react@19.2.8))(@react-email/img@0.0.12(react@19.2.8))(@react-email/link@0.0.13(react@19.2.8))(@react-email/preview@0.0.14(react@19.2.8))(@react-email/text@0.1.6(react@19.2.8))(react@19.2.8)
@@ -42,18 +42,18 @@ importers:
         specifier: 19.2.8
         version: 19.2.8
       react-dom:
-        specifier: 19.2.7
-        version: 19.2.7(react@19.2.8)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       react-email:
         specifier: 6.9.0
-        version: 6.9.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+        version: 6.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@react-email/ui':
         specifier: 6.9.0
-        version: 6.9.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+        version: 6.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
@@ -1397,10 +1397,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-email@6.9.0:
     resolution: {integrity: sha512-72jV+VkeeXgNWDycNDn2tIlHFLg4Hevi3pC77g63FAY1+bDgTs4b56jbZfHF1t5d+GVGb02sGS8bOwoptgvI1w==}
@@ -1983,14 +1983,14 @@ snapshots:
       react: 19.2.8
     optional: true
 
-  '@react-email/render@2.1.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
+  '@react-email/render@2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       entities: 4.5.0
       html-to-text: 9.0.5
       html5parser: 3.0.0
       prettier: 3.8.4
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@react-email/tailwind@2.0.7(@react-email/body@0.3.0(react@19.2.8))(@react-email/button@0.2.1(react@19.2.8))(@react-email/code-block@0.2.1(react@19.2.8))(@react-email/code-inline@0.0.6(react@19.2.8))(@react-email/container@0.0.16(react@19.2.8))(@react-email/heading@0.0.16(react@19.2.8))(@react-email/hr@0.0.12(react@19.2.8))(@react-email/img@0.0.12(react@19.2.8))(@react-email/link@0.0.13(react@19.2.8))(@react-email/preview@0.0.14(react@19.2.8))(@react-email/text@0.1.6(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -2013,10 +2013,10 @@ snapshots:
     dependencies:
       react: 19.2.8
 
-  '@react-email/ui@6.9.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
+  '@react-email/ui@6.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       esbuild: 0.28.1
-      next: 16.2.6(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+      next: 16.2.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
       - '@opentelemetry/api'
@@ -2540,7 +2540,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@16.2.6(react-dom@19.2.7(react@19.2.8))(react@19.2.8):
+  next@16.2.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -2548,7 +2548,7 @@ snapshots:
       caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
@@ -2638,16 +2638,16 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  react-dom@19.2.7(react@19.2.8):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
 
-  react-email@6.9.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8):
+  react-email@6.9.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
-      '@react-email/render': 2.1.0(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+      '@react-email/render': 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       chokidar: 4.0.3
       commander: 13.1.0
       conf: 15.1.0
@@ -2665,7 +2665,7 @@ snapshots:
       prismjs: 1.30.0
       prompts: 2.4.2
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       socket.io: 4.8.3
       tailwindcss: 4.3.3
       tsconfig-paths: 4.2.0

--- a/backend-node/src/security-login.test.ts
+++ b/backend-node/src/security-login.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { render } from "react-email"
+import SecurityLoginEmail from "../emails/security-login"
+
+test("renders a security login email", async () => {
+  const html = await render(
+    SecurityLoginEmail({
+      category: "security_login",
+      subject: "New login to Flathub account",
+      previewText: "Flathub Login",
+      provider: "github",
+      login: "razze",
+      time: "2026-07-22T21:29:50.106441",
+      ipAddress: "2a00:6020:a125:ff00:54e4:dce2:6a21:90d3",
+    }),
+  )
+
+  assert.match(html, /New login to Flathub account/)
+  assert.match(html, /razze/)
+  assert.match(html, /2a00:6020:a125:ff00:54e4:dce2:6a21:90d3/)
+})


### PR DESCRIPTION
Keep React and React DOM on matching versions so React Email can render messages. Add a security-login render test to CI and group future React updates in Dependabot to prevent version skew.