### PR TITLE
Fix Sentry release deployments

### DIFF
--- a/.github/workflows/backend_deploy.yml
+++ b/.github/workflows/backend_deploy.yml
@@ -57,3 +57,15 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Create Sentry release
+        # 3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: flathub
+          SENTRY_PROJECT: backend
+        with:
+          environment: production
+          release: ${{ github.sha }}
+          set_commits: skip

--- a/.github/workflows/backend_node_deploy.yml
+++ b/.github/workflows/backend_node_deploy.yml
@@ -46,8 +46,7 @@ jobs:
           platforms: linux/arm64
           provenance: false
           build-args: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            GITHUB_SHA=${{ github.sha }}
+            SENTRY_RELEASE=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/backend-node:${{ github.sha }}-arm64
             ghcr.io/${{ github.repository_owner }}/backend-node:${{ github.sha }}
@@ -57,3 +56,15 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=ssh://git@github.com:${{ github.repository }}.git
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
+
+      - name: Create Sentry release
+        # 3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: flathub
+          SENTRY_PROJECT: backend-node
+        with:
+          environment: production
+          release: ${{ github.sha }}
+          set_commits: skip

--- a/.github/workflows/frontend_deploy.yml
+++ b/.github/workflows/frontend_deploy.yml
@@ -92,3 +92,15 @@ jobs:
           ssh-keyscan -H hub.flathub.org >> ~/.ssh/known_hosts 2>/dev/null
           rsync -avz ./static/ assets@hub.flathub.org:static/
           rsync -avz ./frontend/public/ assets@hub.flathub.org:public/
+
+      - name: Finalize Sentry release
+        # 3.7.0
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: flathub
+          SENTRY_PROJECT: frontend
+        with:
+          environment: production
+          release: ${{ github.sha }}
+          set_commits: skip

--- a/backend-node/Dockerfile
+++ b/backend-node/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:24
 
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+
 RUN corepack enable pnpm
 
 WORKDIR /app

--- a/backend-node/src/index.ts
+++ b/backend-node/src/index.ts
@@ -228,9 +228,13 @@ const route = createRoute({
 const app = new OpenAPIHono()
 
 app.use("*", (c, next) => {
-  const { SENTRY_DSN } = env<{ SENTRY_DSN: string }>(c)
+  const { SENTRY_DSN, SENTRY_RELEASE } = env<{
+    SENTRY_DSN: string
+    SENTRY_RELEASE?: string
+  }>(c)
   return sentry({
     dsn: SENTRY_DSN,
+    release: SENTRY_RELEASE,
     sampleRate: 0.1,
     tracesSampleRate: 0.1,
   })(c, next)

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,7 @@ import createNextIntlPlugin from "next-intl/plugin"
 import { NextConfig } from "next"
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts")
+const buildId = process.env.GITHUB_SHA
 
 const CONTENT_SECURITY_POLICY = `
   base-uri 'self' ${process.env.NEXT_PUBLIC_SITE_BASE_URI};
@@ -28,8 +29,17 @@ const sentryWebpackPluginOptions = {
   org: "flathub",
   project: "frontend",
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+  // The Docker build does not inherit GitHub Actions' CI environment variable.
+  silent: false,
+
+  release: buildId
+    ? {
+        name: buildId,
+        // Supported by the Sentry build plugin, but missing from @sentry/nextjs' type.
+        setCommits: false as never,
+        finalize: false,
+      }
+    : undefined,
 
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
@@ -52,8 +62,6 @@ const sentryWebpackPluginOptions = {
   // https://vercel.com/docs/cron-jobs
   automaticVercelMonitors: false,
 }
-
-const buildId = process.env.GITHUB_SHA
 
 if (!buildId) {
   console.info(


### PR DESCRIPTION
Finalize releases and record production deploys only after successful image publication. Propagate the release SHA to backend-node events and create releases for all three services.