### PR TITLE
Add unknown version statistics

### DIFF
--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -459,6 +459,14 @@ def _build_or_update_aggregates() -> dict:
     return agg
 
 
+def _add_unknown_version_count(
+    versions: dict[str, int], total: int, reported: int
+) -> None:
+    unknown_count = total - reported
+    if unknown_count > 0:
+        versions["unknown"] = versions.get("unknown", 0) + unknown_count
+
+
 def _compute_recent_version_stats(
     days: int = 30,
 ) -> tuple[dict[str, int], dict[str, int], dict[str, dict[str, int]]]:
@@ -478,9 +486,21 @@ def _compute_recent_version_stats(
         if stats.get("os_versions"):
             for ver, count in stats["os_versions"].items():
                 os_versions[ver] = os_versions.get(ver, 0) + count
+        if stats.get("ostree_versions"):
+            _add_unknown_version_count(
+                os_versions,
+                sum(stats["ostree_versions"].values()),
+                sum(stats.get("os_versions", {}).values()),
+            )
         if stats.get("flatpak_versions"):
             for ver, count in stats["flatpak_versions"].items():
                 flatpak_versions[ver] = flatpak_versions.get(ver, 0) + count
+        if stats.get("ostree_versions"):
+            _add_unknown_version_count(
+                flatpak_versions,
+                sum(stats["ostree_versions"].values()),
+                sum(stats.get("flatpak_versions", {}).values()),
+            )
         if stats.get("os_flatpak_versions"):
             for os_ver, fp_versions in stats["os_flatpak_versions"].items():
                 os_entry = os_flatpak_versions.setdefault(os_ver, {})

--- a/backend/tests/test_version_stats.py
+++ b/backend/tests/test_version_stats.py
@@ -1,0 +1,52 @@
+import datetime
+
+from app import stats
+
+
+def test_add_unknown_version_count():
+    versions = {"1.16": 80, "unknown": 5}
+
+    stats._add_unknown_version_count(versions, total=100, reported=85)
+    stats._add_unknown_version_count(versions, total=10, reported=12)
+
+    assert versions == {"1.16": 80, "unknown": 20}
+
+
+def test_recent_version_stats_adds_unknown_os_from_ostree_total(monkeypatch):
+    end_date = datetime.date(2026, 8, 12)
+    payloads = {
+        end_date: {
+            "ostree_versions": {"1.16": 100},
+            "os_versions": {
+                "fedora;42": 40,
+                "arch;unknown": 25,
+                "unknown": 2,
+            },
+            "flatpak_versions": {"1.16": 80, "unknown": 5},
+        },
+        end_date - datetime.timedelta(days=1): {
+            "ostree_versions": {"1.16": 10},
+            "os_versions": {"fedora;42": 12},
+            "flatpak_versions": {"1.16": 12},
+        },
+        end_date - datetime.timedelta(days=2): {
+            "os_versions": {"debian;13": 5},
+        },
+    }
+
+    monkeypatch.setattr(
+        stats.utils,
+        "utcnow",
+        lambda: datetime.datetime(2026, 8, 14, tzinfo=datetime.UTC),
+    )
+    monkeypatch.setattr(stats, "_get_stats_for_date", payloads.get)
+
+    os_versions, flatpak_versions, _ = stats._compute_recent_version_stats(days=3)
+
+    assert os_versions == {
+        "fedora;42": 52,
+        "arch;unknown": 25,
+        "debian;13": 5,
+        "unknown": 35,
+    }
+    assert flatpak_versions == {"1.16": 92, "unknown": 20}


### PR DESCRIPTION
Use OSTree totals to account for pings that omit OS or Flatpak version data, preserving accurate distribution percentages. Add regression coverage for accumulation and inconsistent daily totals.