### PR TITLE
Add curated selection layouts to backend

### DIFF
--- a/backend/alembic/versions/7c2e4a6b8d10_add_curated_selection_layout.py
+++ b/backend/alembic/versions/7c2e4a6b8d10_add_curated_selection_layout.py
@@ -1,0 +1,36 @@
+"""Add curated selection layout
+
+Revision ID: 7c2e4a6b8d10
+Revises: 518a0e462ba8
+Create Date: 2026-08-15 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "7c2e4a6b8d10"
+down_revision = "518a0e462ba8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "scheduledselection",
+        sa.Column("layout", sa.String(), server_default="grid", nullable=False),
+    )
+    op.create_check_constraint(
+        "scheduledselection_layout",
+        "scheduledselection",
+        "layout IN ('grid', 'carousel')",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "scheduledselection_layout", "scheduledselection", type_="check"
+    )
+    op.drop_column("scheduledselection", "layout")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2915,6 +2915,7 @@ class ScheduledSelection(Base):
         Integer, ForeignKey(SelectionTheme.id), nullable=False, index=True
     )
     slot = mapped_column(String, nullable=False, index=True)
+    layout = mapped_column(String, nullable=False, server_default="grid")
     starts_at = mapped_column(Date, nullable=False, index=True)
     ends_at = mapped_column(Date, nullable=False, index=True)
     enabled = mapped_column(Boolean, nullable=False, server_default=false())
@@ -2938,6 +2939,10 @@ class ScheduledSelection(Base):
         CheckConstraint(
             "slot IN ('after-hero', 'after-top-apps', 'after-first-category-block')",
             name="scheduledselection_slot",
+        ),
+        CheckConstraint(
+            "layout IN ('grid', 'carousel')",
+            name="scheduledselection_layout",
         ),
         ExcludeConstraint(
             (slot, "="),
@@ -3262,6 +3267,18 @@ class App(Base):
         if app:
             return app.is_fullscreen_app
         return False
+
+    @classmethod
+    def fullscreen_app_ids(cls, db, app_ids: set[str]) -> set[str]:
+        if not app_ids:
+            return set()
+
+        return {
+            app_id
+            for (app_id,) in db.session.query(App.app_id)
+            .filter(App.app_id.in_(app_ids), App.is_fullscreen_app == true())
+            .all()
+        }
 
     @classmethod
     def set_fullscreen_app(cls, db, app_id: str, is_fullscreen_app: bool) -> None:

--- a/backend/app/routes/app_picks.py
+++ b/backend/app/routes/app_picks.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import StrEnum
 from typing import Annotated
 
 from fastapi import APIRouter, FastAPI, HTTPException, Path
@@ -77,12 +78,19 @@ class AppsOfTheWeek(BaseModel):
 class CuratedAppSelectionApp(BaseModel):
     app_id: str
     position: int
+    isFullscreen: bool
+
+
+class CuratedAppSelectionLayout(StrEnum):
+    GRID = "grid"
+    CAROUSEL = "carousel"
 
 
 class CuratedAppSelection(BaseModel):
     id: int
     theme_key: str
     slot: str
+    layout: CuratedAppSelectionLayout
     starts_at: datetime.date
     ends_at: datetime.date
     apps: list[CuratedAppSelectionApp]
@@ -107,6 +115,7 @@ class ScheduledSelectionAppInput(BaseModel):
 class ScheduledSelectionInput(BaseModel):
     theme_id: int
     slot: str
+    layout: CuratedAppSelectionLayout = CuratedAppSelectionLayout.GRID
     starts_at: datetime.date
     ends_at: datetime.date
     enabled: bool = False
@@ -129,10 +138,15 @@ def _theme_to_response(theme: models.SelectionTheme) -> SelectionTheme:
 
 def _selection_to_response(
     selection: models.ScheduledSelection,
+    fullscreen_app_ids: set[str],
     allowed_app_ids: set[str] | None = None,
 ) -> CuratedAppSelection | None:
     apps = [
-        CuratedAppSelectionApp(app_id=app.app_id, position=app.position)
+        CuratedAppSelectionApp(
+            app_id=app.app_id,
+            position=app.position,
+            isFullscreen=app.app_id in fullscreen_app_ids,
+        )
         for app in selection.apps
         if allowed_app_ids is None or app.app_id in allowed_app_ids
     ]
@@ -143,6 +157,7 @@ def _selection_to_response(
         id=selection.id,
         theme_key=selection.theme.key,
         slot=selection.slot,
+        layout=selection.layout,
         starts_at=selection.starts_at,
         ends_at=selection.ends_at,
         apps=apps,
@@ -151,8 +166,9 @@ def _selection_to_response(
 
 def _selection_to_admin_response(
     selection: models.ScheduledSelection,
+    fullscreen_app_ids: set[str],
 ) -> ScheduledSelectionAdmin:
-    public_selection = _selection_to_response(selection)
+    public_selection = _selection_to_response(selection, fullscreen_app_ids)
     if public_selection is None:
         raise HTTPException(500, "Scheduled selection has no apps")
 
@@ -170,6 +186,12 @@ def _app_pick_recommendation_ids(db, recommendation_date: datetime.date) -> set[
             db, recommendation_date
         ).recommendations
     }
+
+
+def _selection_app_ids(
+    selections: list[models.ScheduledSelection],
+) -> set[str]:
+    return {app.app_id for selection in selections for app in selection.apps}
 
 
 def _validate_scheduled_selection(
@@ -269,13 +291,19 @@ async def get_curated_app_selections(
 ) -> CuratedAppSelections:
     with get_db("replica") as db:
         allowed_app_ids = _app_pick_recommendation_ids(db, date)
+        active_selections = models.ScheduledSelection.active_by_date(db, date)
+        fullscreen_app_ids = models.App.fullscreen_app_ids(
+            db, _selection_app_ids(active_selections)
+        )
         selections = []
         used_slots = set()
-        for selection in models.ScheduledSelection.active_by_date(db, date):
+        for selection in active_selections:
             if selection.slot in used_slots:
                 continue
 
-            response = _selection_to_response(selection, allowed_app_ids)
+            response = _selection_to_response(
+                selection, fullscreen_app_ids, allowed_app_ids
+            )
             if response is None:
                 continue
 
@@ -359,9 +387,13 @@ async def get_curated_app_selections_admin(
     _moderator: QualityModeratorDep,
 ) -> list[ScheduledSelectionAdmin]:
     with get_db("writer") as db:
+        selections = models.ScheduledSelection.all(db)
+        fullscreen_app_ids = models.App.fullscreen_app_ids(
+            db, _selection_app_ids(selections)
+        )
         return [
-            _selection_to_admin_response(selection)
-            for selection in models.ScheduledSelection.all(db)
+            _selection_to_admin_response(selection, fullscreen_app_ids)
+            for selection in selections
         ]
 
 
@@ -386,6 +418,7 @@ async def create_curated_app_selection_admin(
         selection = models.ScheduledSelection(
             theme_id=body.theme_id,
             slot=body.slot,
+            layout=body.layout,
             starts_at=body.starts_at,
             ends_at=body.ends_at,
             enabled=body.enabled,
@@ -402,7 +435,10 @@ async def create_curated_app_selection_admin(
             for app in sorted(body.apps, key=lambda app: app.position)
         ]
         db.session.flush()
-        result = _selection_to_admin_response(selection)
+        fullscreen_app_ids = models.App.fullscreen_app_ids(
+            db, {app.app_id for app in selection.apps}
+        )
+        result = _selection_to_admin_response(selection, fullscreen_app_ids)
 
     await cache.invalidate_cache_by_pattern(
         "cache:endpoint:get_curated_app_selections:*"
@@ -438,6 +474,7 @@ async def update_curated_app_selection_admin(
         selection.theme_id = body.theme_id
         selection.theme = theme
         selection.slot = body.slot
+        selection.layout = body.layout
         selection.starts_at = body.starts_at
         selection.ends_at = body.ends_at
         selection.enabled = body.enabled
@@ -454,7 +491,10 @@ async def update_curated_app_selection_admin(
             for app in sorted(body.apps, key=lambda app: app.position)
         ]
         db.session.flush()
-        result = _selection_to_admin_response(selection)
+        fullscreen_app_ids = models.App.fullscreen_app_ids(
+            db, {app.app_id for app in selection.apps}
+        )
+        result = _selection_to_admin_response(selection, fullscreen_app_ids)
 
     await cache.invalidate_cache_by_pattern(
         "cache:endpoint:get_curated_app_selections:*"

--- a/backend/tests/snapshots/curated_app_selections__curated_app_selections_admin_smoke__test_curated_app_selections_admin.json
+++ b/backend/tests/snapshots/curated_app_selections__curated_app_selections_admin_smoke__test_curated_app_selections_admin.json
@@ -3,16 +3,19 @@
     "id": 1,
     "theme_key": "creative-tools",
     "slot": "after-hero",
+    "layout": "carousel",
     "starts_at": "2026-07-05",
     "ends_at": "2026-07-10",
     "apps": [
       {
         "app_id": "org.example.App",
-        "position": 0
+        "position": 0,
+        "isFullscreen": true
       },
       {
         "app_id": "org.example.Invalid",
-        "position": 1
+        "position": 1,
+        "isFullscreen": false
       }
     ],
     "theme_id": 1,

--- a/backend/tests/snapshots/curated_app_selections__curated_app_selections_smoke__test_curated_app_selections.json
+++ b/backend/tests/snapshots/curated_app_selections__curated_app_selections_smoke__test_curated_app_selections.json
@@ -4,12 +4,14 @@
       "id": 1,
       "theme_key": "creative-tools",
       "slot": "after-hero",
+      "layout": "carousel",
       "starts_at": "2026-07-05",
       "ends_at": "2026-07-10",
       "apps": [
         {
           "app_id": "org.example.App",
-          "position": 0
+          "position": 0,
+          "isFullscreen": true
         }
       ]
     }

--- a/backend/tests/test_curated_app_selections.py
+++ b/backend/tests/test_curated_app_selections.py
@@ -34,6 +34,15 @@ def moderator_override(client):
 
 
 @pytest.fixture
+def fullscreen_lookup(monkeypatch):
+    monkeypatch.setattr(
+        app_picks.models.App,
+        "fullscreen_app_ids",
+        lambda _db, app_ids: {"org.example.App"} & app_ids,
+    )
+
+
+@pytest.fixture
 def curated_selection():
     return SimpleNamespace(
         id=1,
@@ -41,6 +50,7 @@ def curated_selection():
         enabled=True,
         theme=SimpleNamespace(key="creative-tools"),
         slot="after-hero",
+        layout="carousel",
         starts_at=datetime.date(2026, 7, 5),
         ends_at=datetime.date(2026, 7, 10),
         apps=[
@@ -50,11 +60,14 @@ def curated_selection():
     )
 
 
-def test_curated_app_selections_smoke(client, snapshot, monkeypatch, curated_selection):
+def test_curated_app_selections_smoke(
+    client, snapshot, monkeypatch, curated_selection, fullscreen_lookup
+):
     duplicate_slot = SimpleNamespace(
         id=2,
         theme=SimpleNamespace(key="creative-tools"),
         slot="after-hero",
+        layout="carousel",
         starts_at=datetime.date(2026, 7, 5),
         ends_at=datetime.date(2026, 7, 10),
         apps=[SimpleNamespace(app_id="org.example.Other", position=0)],
@@ -172,7 +185,12 @@ def test_curated_app_selection_themes_admin_smoke(
 
 
 def test_curated_app_selections_admin_smoke(
-    client, snapshot, monkeypatch, moderator_override, curated_selection
+    client,
+    snapshot,
+    monkeypatch,
+    moderator_override,
+    curated_selection,
+    fullscreen_lookup,
 ):
     monkeypatch.setattr(
         app_picks.models.ScheduledSelection,
@@ -184,3 +202,15 @@ def test_curated_app_selections_admin_smoke(
 
     assert response.status_code == 200
     assert snapshot("test_curated_app_selections_admin.json") == response.json()
+
+
+def test_scheduled_selection_input_defaults_to_grid():
+    selection = app_picks.ScheduledSelectionInput(
+        theme_id=1,
+        slot="after-hero",
+        starts_at=datetime.date(2026, 7, 5),
+        ends_at=datetime.date(2026, 7, 10),
+        apps=[],
+    )
+
+    assert selection.layout == app_picks.CuratedAppSelectionLayout.GRID


### PR DESCRIPTION
Persist grid and carousel choices for scheduled homepage selections and expose them through public and admin responses. Include fullscreen metadata with a bulk lookup so carousel banners can match weekly app positioning.


@AlexanderVanhee 