### PR TITLE
Fix homepage theme selection crash

### DIFF
--- a/frontend/@/components/ui/select.stories.tsx
+++ b/frontend/@/components/ui/select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+import { expect, userEvent, within } from "storybook/test"
 
 import {
   Select,
@@ -32,6 +33,58 @@ export const Default: Story = {
           <SelectItem value="test3">test 3</SelectItem>
         </SelectContent>
       </Select>
+    )
+  },
+}
+
+export const TitleWithDescription: Story = {
+  args: {},
+  render: function Render(args) {
+    const [value, setValue] = React.useState<string>()
+
+    return (
+      <Select value={value} onValueChange={setValue}>
+        <SelectTrigger className="w-[300px]">
+          <SelectValue placeholder="Select a theme" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value="notes"
+            description={
+              <span className="text-xs opacity-75">
+                Find your new favorite note taking tool
+              </span>
+            }
+          >
+            Take Better Notes
+          </SelectItem>
+          <SelectItem
+            value="tasks"
+            description={
+              <span className="text-xs opacity-75">
+                Stay on top of every task
+              </span>
+            }
+          >
+            Get Things Done
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const page = within(canvasElement.ownerDocument.body)
+    const trigger = canvas.getByRole("combobox")
+
+    await userEvent.click(trigger)
+    await userEvent.click(
+      page.getByRole("option", { name: "Take Better Notes" }),
+    )
+
+    await expect(trigger).toHaveTextContent("Take Better Notes")
+    await expect(trigger).not.toHaveTextContent(
+      "Find your new favorite note taking tool",
     )
   },
 }

--- a/frontend/@/components/ui/select.tsx
+++ b/frontend/@/components/ui/select.tsx
@@ -101,8 +101,11 @@ function SelectLabel({
 function SelectItem({
   className,
   children,
+  description,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: React.ComponentProps<typeof SelectPrimitive.Item> & {
+  description?: React.ReactNode
+}) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -117,7 +120,14 @@ function SelectItem({
           <CheckIcon className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      {description ? (
+        <span className="flex min-w-0 flex-col">
+          <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+          {description}
+        </span>
+      ) : (
+        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      )}
     </SelectPrimitive.Item>
   )
 }

--- a/frontend/app/[locale]/(protected)/admin/homepage-selections/homepage-selections-client.tsx
+++ b/frontend/app/[locale]/(protected)/admin/homepage-selections/homepage-selections-client.tsx
@@ -298,11 +298,6 @@ export default function HomepageSelectionsClient() {
       ),
     [t, themesQuery.data],
   )
-  const selectedThemeTitle = form.themeId
-    ? (themeLabelsById.get(Number(form.themeId))?.title ??
-      themesById.get(Number(form.themeId))?.name)
-    : undefined
-
   const availableApps = useMemo(() => {
     const selectedAppIds = new Set(form.apps.map((app) => app.id))
     return (recommendationsQuery.data ?? []).filter(
@@ -570,9 +565,7 @@ export default function HomepageSelectionsClient() {
                         className={SELECT_TRIGGER_CLASS}
                         aria-label="Theme"
                       >
-                        <SelectValue placeholder="Select a theme">
-                          {selectedThemeTitle}
-                        </SelectValue>
+                        <SelectValue placeholder="Select a theme" />
                       </SelectTrigger>
                       <SelectContent className={SELECT_CONTENT_CLASS}>
                         {(themesQuery.data ?? []).map((theme) => {
@@ -584,18 +577,16 @@ export default function HomepageSelectionsClient() {
                               value={theme.id.toString()}
                               disabled={!theme.enabled}
                               className={SELECT_ITEM_CLASS}
-                            >
-                              <span className="flex flex-col py-1">
-                                <span>
-                                  {label?.title ?? theme.name}
-                                  {!theme.enabled ? " (disabled)" : ""}
-                                </span>
-                                {label?.subtitle ? (
+                              description={
+                                label?.subtitle ? (
                                   <span className="text-xs opacity-75">
                                     {label.subtitle}
                                   </span>
-                                ) : null}
-                              </span>
+                                ) : undefined
+                              }
+                            >
+                              {label?.title ?? theme.name}
+                              {!theme.enabled ? " (disabled)" : ""}
                             </SelectItem>
                           )
                         })}


### PR DESCRIPTION
Let Radix render the selected item text instead of replacing SelectValue children during portal cleanup. Keep theme descriptions in the menu through a separate SelectItem description and cover the selected-title behavior in Storybook.