### PR TITLE
Prevent stale app-of-the-day admin reads

### DIFF
--- a/backend/app/routes/app_picks.py
+++ b/backend/app/routes/app_picks.py
@@ -314,6 +314,36 @@ async def get_curated_app_selections(
 
 
 @router.get(
+    "/admin/app-of-the-day/{date}",
+    tags=["app-picks"],
+    responses={
+        200: {"description": "App of the day"},
+        401: {"description": "Unauthorized"},
+        403: {"description": "Forbidden - quality moderator required"},
+        422: {"description": "Validation error"},
+        500: {"description": "Internal server error"},
+    },
+)
+@cache.private
+async def get_app_of_the_day_admin(
+    date: AppPickDate,
+    _moderator: QualityModeratorDep,
+) -> AppOfTheDay:
+    """Returns the app of the day for the admin page, bypassing shared caches"""
+    with get_db("writer") as db:
+        app_of_the_day = models.AppOfTheDay.by_date(db, date)
+
+        if app_of_the_day is None:
+            return AppOfTheDay(app_id="tv.kodi.Kodi", day=date)
+
+        app = models.App.by_appid(db, app_of_the_day.app_id)
+        if app and app.excluded_from_app_picks:
+            return AppOfTheDay(app_id="tv.kodi.Kodi", day=date)
+
+        return AppOfTheDay(app_id=app_of_the_day.app_id, day=date)
+
+
+@router.get(
     "/admin/apps-of-the-week/{date}",
     tags=["app-picks"],
     responses={

--- a/backend/tests/test_app_picks.py
+++ b/backend/tests/test_app_picks.py
@@ -1,0 +1,51 @@
+import os
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(ROOT_DIR)
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import cache
+from app.login_info import quality_moderator_only
+from app.routes import app_picks
+
+
+def test_get_app_of_the_day_admin_bypasses_shared_cache_and_replica():
+    database_types = []
+
+    @contextmanager
+    def fake_get_db(database_type):
+        database_types.append(database_type)
+        yield object()
+
+    app = FastAPI()
+    app.dependency_overrides[quality_moderator_only] = lambda: object()
+    app_picks.register_to_app(app)
+    app.add_middleware(cache.CacheControlMiddleware)
+
+    with (
+        patch("app.routes.app_picks.get_db", side_effect=fake_get_db),
+        patch(
+            "app.routes.app_picks.models.AppOfTheDay.by_date",
+            return_value=SimpleNamespace(app_id="org.example.App"),
+        ),
+        patch(
+            "app.routes.app_picks.models.App.by_appid",
+            return_value=SimpleNamespace(excluded_from_app_picks=False),
+        ),
+        TestClient(app) as client,
+    ):
+        response = client.get("/app-picks/admin/app-of-the-day/2026-08-27")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "app_id": "org.example.App",
+        "day": "2026-08-27",
+    }
+    assert response.headers["Cache-Control"] == "private"
+    assert database_types == ["writer"]

--- a/frontend/src/codegen/app-picks/app-picks.msw.ts
+++ b/frontend/src/codegen/app-picks/app-picks.msw.ts
@@ -69,6 +69,15 @@ export const getGetCuratedAppSelectionsAppPicksCuratedAppSelectionsDateGetRespon
     ...overrideResponse,
   })
 
+export const getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetResponseMock =
+  (
+    overrideResponse: Partial<Extract<AppOfTheDay, object>> = {},
+  ): AppOfTheDay => ({
+    app_id: faker.string.alpha({ length: { min: 10, max: 20 } }),
+    day: faker.date.past().toISOString().slice(0, 10),
+    ...overrideResponse,
+  })
+
 export const getGetAppOfTheWeekAdminAppPicksAdminAppsOfTheWeekDateGetResponseMock =
   (
     overrideResponse: Partial<Extract<AppsOfTheWeek, object>> = {},
@@ -248,6 +257,31 @@ export const getGetCuratedAppSelectionsAppPicksCuratedAppSelectionsDateGetMockHa
               ? await overrideResponse(info)
               : overrideResponse
             : getGetCuratedAppSelectionsAppPicksCuratedAppSelectionsDateGetResponseMock(),
+          { status: 200 },
+        )
+      },
+      options,
+    )
+  }
+
+export const getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetMockHandler =
+  (
+    overrideResponse?:
+      | AppOfTheDay
+      | ((
+          info: Parameters<Parameters<typeof http.get>[1]>[0],
+        ) => Promise<AppOfTheDay> | AppOfTheDay),
+    options?: RequestHandlerOptions,
+  ) => {
+    return http.get(
+      "*/app-picks/admin/app-of-the-day/:date",
+      async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {
+        return HttpResponse.json(
+          overrideResponse !== undefined
+            ? typeof overrideResponse === "function"
+              ? await overrideResponse(info)
+              : overrideResponse
+            : getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetResponseMock(),
           { status: 200 },
         )
       },
@@ -452,6 +486,7 @@ export const getAppPicksMock = () => [
   getGetAppOfTheDayAppPicksAppOfTheDayDateGetMockHandler(),
   getGetAppOfTheWeekAppPicksAppsOfTheWeekDateGetMockHandler(),
   getGetCuratedAppSelectionsAppPicksCuratedAppSelectionsDateGetMockHandler(),
+  getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetMockHandler(),
   getGetAppOfTheWeekAdminAppPicksAdminAppsOfTheWeekDateGetMockHandler(),
   getGetCuratedAppSelectionThemesAdminAppPicksAdminCuratedAppSelectionThemesGetMockHandler(),
   getGetCuratedAppSelectionsAdminAppPicksAdminCuratedAppSelectionsGetMockHandler(),

--- a/frontend/src/codegen/app-picks/app-picks.ts
+++ b/frontend/src/codegen/app-picks/app-picks.ts
@@ -659,6 +659,227 @@ export function useGetCuratedAppSelectionsAppPicksCuratedAppSelectionsDateGet<
 }
 
 /**
+ * Returns the app of the day for the admin page, bypassing shared caches
+ * @summary Get App Of The Day Admin
+ */
+export const getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet = (
+  date: string,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<AppOfTheDay>> => {
+  return axios.get(`/app-picks/admin/app-of-the-day/${date}`, options)
+}
+
+export const getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryKey = (
+  date: string,
+) => {
+  return [`/app-picks/admin/app-of-the-day/${date}`] as const
+}
+
+export const getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryOptions =
+  <
+    TData = Awaited<
+      ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+    >,
+    TError = AxiosError<void>,
+  >(
+    date: string,
+    options?: {
+      query?: Partial<
+        UseQueryOptions<
+          Awaited<
+            ReturnType<
+              typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet
+            >
+          >,
+          TError,
+          TData
+        >
+      >
+      axios?: AxiosRequestConfig
+    },
+  ) => {
+    const { query: queryOptions, axios: axiosOptions } = options ?? {}
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryKey(date)
+
+    const queryFn: QueryFunction<
+      Awaited<
+        ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+      >
+    > = ({ signal }) =>
+      getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet(date, {
+        signal,
+        ...axiosOptions,
+      })
+
+    return {
+      queryKey,
+      queryFn,
+      enabled: date !== null && date !== undefined,
+      ...queryOptions,
+    } as UseQueryOptions<
+      Awaited<
+        ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+      >,
+      TError,
+      TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> }
+  }
+
+export type GetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryResult =
+  NonNullable<
+    Awaited<
+      ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+    >
+  >
+export type GetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryError =
+  AxiosError<void>
+
+export function useGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet<
+  TData = Awaited<
+    ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+  >,
+  TError = AxiosError<void>,
+>(
+  date: string,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet
+            >
+          >
+        >,
+        "initialData"
+      >
+    axios?: AxiosRequestConfig
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>
+}
+export function useGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet<
+  TData = Awaited<
+    ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+  >,
+  TError = AxiosError<void>,
+>(
+  date: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+        >,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<
+            ReturnType<
+              typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet
+            >
+          >,
+          TError,
+          Awaited<
+            ReturnType<
+              typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet
+            >
+          >
+        >,
+        "initialData"
+      >
+    axios?: AxiosRequestConfig
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>
+}
+export function useGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet<
+  TData = Awaited<
+    ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+  >,
+  TError = AxiosError<void>,
+>(
+  date: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+        >,
+        TError,
+        TData
+      >
+    >
+    axios?: AxiosRequestConfig
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>
+}
+/**
+ * @summary Get App Of The Day Admin
+ */
+
+export function useGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet<
+  TData = Awaited<
+    ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+  >,
+  TError = AxiosError<void>,
+>(
+  date: string,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<
+          ReturnType<typeof getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet>
+        >,
+        TError,
+        TData
+      >
+    >
+    axios?: AxiosRequestConfig
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>
+} {
+  const queryOptions =
+    getGetAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGetQueryOptions(
+      date,
+      options,
+    )
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> }
+
+  return withQueryKey(query, queryOptions.queryKey)
+}
+
+/**
  * Returns apps of the week for the admin page, bypassing CDN cache
  * @summary Get App Of The Week Admin
  */

--- a/frontend/src/components/app-picks/AppOfTheDayChanger.tsx
+++ b/frontend/src/components/app-picks/AppOfTheDayChanger.tsx
@@ -8,7 +8,7 @@ import {
 } from "date-fns"
 import {
   DesktopAppstream,
-  getAppOfTheDayAppPicksAppOfTheDayDateGet,
+  getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet,
   getAppstreamAppstreamAppIdGet,
 } from "src/codegen"
 import { AppOfTheDay } from "../application/AppOfTheDay"
@@ -29,9 +29,11 @@ export const AppOfTheDayChanger = ({ selectableApps, day }) => {
     queryKey: ["app-of-the-day", day],
     queryFn: async () => {
       try {
-        const response = await getAppOfTheDayAppPicksAppOfTheDayDateGet(
-          formatISO(day, { representation: "date" }),
-        )
+        const response =
+          await getAppOfTheDayAdminAppPicksAdminAppOfTheDayDateGet(
+            formatISO(day, { representation: "date" }),
+            { withCredentials: true },
+          )
 
         const getAppsOfTheDay = response.data
 


### PR DESCRIPTION
Use a private admin endpoint backed by the writer database instead of the cached public endpoint. This keeps app-pick edits visible immediately while preserving caching for public traffic.