### PR TITLE
Improve app card icon quality

### DIFF
--- a/frontend/src/components/application/ApplicationCard.tsx
+++ b/frontend/src/components/application/ApplicationCard.tsx
@@ -140,6 +140,7 @@ export const ApplicationCard = ({
           iconUrl={application.icon}
           appName={application.name}
           priority={priority}
+          quality={100}
           size={96}
         />
       </div>


### PR DESCRIPTION
Request maximum imgproxy quality for app card icons to avoid visible compression artifacts on the start page.