### PR TITLE
Fix year-in-review Redis cache access

### DIFF
--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -978,7 +978,10 @@ async def _build_year_in_review_base(year: int) -> dict | None:
     async def _fetch_stats_async(date):
         cache_key = f"stats:date:{date.isoformat()}"
         try:
-            cached_value = await redis_conn.get(cache_key)
+            cached_value = cast(
+                "bytes | str | None",
+                await asyncio.to_thread(redis_conn.get, cache_key),
+            )
         except Exception:
             logger.exception("Failed to read cached stats for %s", date)
             cached_value = None
@@ -1000,7 +1003,12 @@ async def _build_year_in_review_base(year: int) -> dict | None:
             try:
                 today = utils.utcnow().date()
                 ttl_seconds = 60 * 60 if date.year == today.year else 60 * 60 * 24 * 7
-                await redis_conn.set(cache_key, orjson.dumps(data), ex=ttl_seconds)
+                await asyncio.to_thread(
+                    redis_conn.set,
+                    cache_key,
+                    orjson.dumps(data),
+                    ex=ttl_seconds,
+                )
             except Exception:
                 # If caching fails, just proceed without cache
                 logger.exception("Failed to cache stats for %s", date)

--- a/backend/tests/test_version_stats.py
+++ b/backend/tests/test_version_stats.py
@@ -1,4 +1,9 @@
+import asyncio
 import datetime
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import orjson
 
 from app import stats
 
@@ -50,3 +55,37 @@ def test_recent_version_stats_adds_unknown_os_from_ostree_total(monkeypatch):
         "unknown": 35,
     }
     assert flatpak_versions == {"1.16": 92, "unknown": 20}
+
+
+def test_year_in_review_uses_sync_redis_cache(monkeypatch):
+    cached_stats = {
+        "updates": 7,
+        "refs": {},
+        "ref_by_country": {},
+    }
+    get_cached = MagicMock(return_value=orjson.dumps(cached_stats))
+    get_source_stats = MagicMock()
+
+    @contextmanager
+    def empty_db(*args, **kwargs):
+        sqldb = MagicMock()
+        sqldb.query.return_value.filter.return_value.all.return_value = []
+        yield sqldb
+
+    monkeypatch.setattr(
+        stats.utils,
+        "utcnow",
+        lambda: datetime.datetime(2018, 4, 29, tzinfo=datetime.UTC),
+    )
+    monkeypatch.setattr(stats.redis_conn, "get", get_cached)
+    monkeypatch.setattr(stats, "_get_stats_for_date", get_source_stats)
+    monkeypatch.setattr(stats.database, "get_db", empty_db)
+    monkeypatch.setattr(stats.database, "get_all_appids_for_frontend", set)
+    monkeypatch.setattr(stats, "_get_app_stats_per_day", dict)
+
+    result = asyncio.run(stats._build_year_in_review_base(2018))
+
+    assert result is not None
+    assert result["updates_count"] == 7
+    get_cached.assert_called_once_with("stats:date:2018-04-29")
+    get_source_stats.assert_not_called()


### PR DESCRIPTION
The shared Redis connection is synchronous, so awaiting its get and set results raises TypeError and discards valid cache hits. Run both operations in worker threads to keep the async aggregation path non-blocking.