### PR TITLE
Allow removing unavailable favorites

### DIFF
--- a/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.stories.tsx
+++ b/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite"
+import { HttpResponse, http } from "msw"
+import { expect, userEvent, waitFor, within } from "storybook/test"
+
+import {
+  UserContext,
+  UserDispatchContext,
+} from "../../../../src/context/user-info"
+import MyFlathubClient from "./my-flathub-client"
+
+const availableAppId = "tv.kodi.Kodi"
+const unavailableAppId = "org.example.Unavailable"
+let favoriteIds: string[] = []
+
+const meta = {
+  title: "pages/my-flathub",
+  component: MyFlathubClient,
+  args: {
+    locale: "en",
+  },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+    msw: {
+      handlers: [
+        http.get("*/favorites", () =>
+          HttpResponse.json(
+            favoriteIds.map((appId) => ({
+              app_id: appId,
+              created_at: "2024-01-01T00:00:00Z",
+            })),
+          ),
+        ),
+        http.get("*/appstream/:appId", ({ params }) => {
+          if (params.appId === unavailableAppId) {
+            return new HttpResponse(null, { status: 404 })
+          }
+
+          return HttpResponse.json({
+            id: availableAppId,
+            name: "Kodi",
+            summary: "A media player",
+            icon: "https://dl.flathub.org/media/tv/kodi/Kodi/4f8cbfae09dc6c8c55501a5d3f604fbb/icons/128x128/tv.kodi.Kodi.png",
+          })
+        }),
+        http.delete("*/favorites/:appId/remove", ({ params }) => {
+          favoriteIds = favoriteIds.filter((appId) => appId !== params.appId)
+          return new HttpResponse(null, { status: 200 })
+        }),
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <UserContext value={{ loading: false, info: { owned_flatpaks: [] } }}>
+        <UserDispatchContext value={() => undefined}>
+          <Story />
+        </UserDispatchContext>
+      </UserContext>
+    ),
+  ],
+  beforeEach: () => {
+    favoriteIds = [availableAppId, unavailableAppId]
+  },
+} satisfies Meta<typeof MyFlathubClient>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const WithUnavailableFavorite: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const removeButton = await canvas.findByRole("button", {
+      name: `Remove ${unavailableAppId} from bookmarks`,
+    })
+
+    await userEvent.click(removeButton)
+
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole("link", { name: unavailableAppId }),
+      ).not.toBeInTheDocument()
+    })
+    expect(canvas.getByRole("link", { name: "Kodi" })).toBeInTheDocument()
+  },
+}

--- a/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
+++ b/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
@@ -78,16 +78,16 @@ const RemoveFavoriteButton = ({
       data-remove-favorite
       variant="ghost"
       size="icon"
-      className="text-destructive hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-auto"
+      className="text-flathub-sonic-silver hover:bg-destructive/10 hover:text-destructive active:bg-destructive/15 active:text-destructive focus-visible:text-destructive disabled:pointer-events-auto dark:text-flathub-spanish-gray dark:hover:text-destructive"
       title={label}
       aria-label={label}
       disabled={removeMutation.isPending}
       onClick={() => removeMutation.mutate({ appId })}
     >
       {removeMutation.isPending ? (
-        <Loader2 className="animate-spin" />
+        <Loader2 className="size-4 animate-spin" />
       ) : (
-        <BookmarkMinus />
+        <BookmarkMinus className="size-4" />
       )}
     </Button>
   )

--- a/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
+++ b/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
@@ -77,7 +77,7 @@ const RemoveFavoriteButton = ({
       ref={buttonRef}
       data-remove-favorite
       variant="ghost"
-      size="icon"
+      size="sm"
       className="text-flathub-sonic-silver hover:bg-destructive/10 hover:text-destructive active:bg-destructive/15 active:text-destructive focus-visible:text-destructive disabled:pointer-events-auto dark:text-flathub-spanish-gray dark:hover:text-destructive"
       title={label}
       aria-label={label}
@@ -89,6 +89,7 @@ const RemoveFavoriteButton = ({
       ) : (
         <BookmarkMinus className="size-4" />
       )}
+      {t("remove-bookmark")}
     </Button>
   )
 }

--- a/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
+++ b/frontend/app/[locale]/(protected)/my-flathub/my-flathub-client.tsx
@@ -5,15 +5,92 @@ import UserApps from "../../../../src/components/user/UserApps"
 import { IS_PRODUCTION } from "../../../../src/env"
 import Breadcrumbs from "../../../../src/components/Breadcrumbs"
 import ApplicationCollectionSuspense from "../../../../src/components/application/ApplicationCollectionSuspense"
-import { useGetFavoritesFavoritesGet } from "../../../../src/codegen"
+import {
+  useGetFavoritesFavoritesGet,
+  useRemoveFromFavoritesFavoritesAppIdRemoveDelete,
+} from "../../../../src/codegen"
 import Spinner from "../../../../src/components/Spinner"
 import { getAppsInfo } from "../../../../src/asyncs/app"
 import { useQuery } from "@tanstack/react-query"
-import type { JSX } from "react"
+import { useRef, type JSX } from "react"
 import CodeCopy from "../../../../src/components/application/CodeCopy"
+import { Button } from "@/components/ui/button"
+import { BookmarkMinus, Loader2 } from "lucide-react"
+import { toast } from "sonner"
 
 interface MyFlathubClientProps {
   locale: string
+}
+
+const RemoveFavoriteButton = ({
+  appId,
+  appName,
+  onRemoved,
+}: {
+  appId: string
+  appName: string
+  onRemoved: () => Promise<unknown> | void
+}) => {
+  const t = useTranslations()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const removeMutation = useRemoveFromFavoritesFavoritesAppIdRemoveDelete({
+    axios: { withCredentials: true },
+    mutation: {
+      onSuccess: async () => {
+        const buttons = Array.from(
+          document.querySelectorAll<HTMLButtonElement>(
+            "[data-remove-favorite]",
+          ),
+        )
+        const buttonIndex = buttonRef.current
+          ? buttons.indexOf(buttonRef.current)
+          : -1
+
+        await onRemoved()
+
+        requestAnimationFrame(() => {
+          const remainingButtons = document.querySelectorAll<HTMLButtonElement>(
+            "[data-remove-favorite]",
+          )
+          const nextButton =
+            remainingButtons[
+              Math.min(Math.max(buttonIndex, 0), remainingButtons.length - 1)
+            ]
+
+          if (nextButton) {
+            nextButton.focus()
+          } else {
+            document
+              .querySelector<HTMLElement>("[data-my-flathub-heading]")
+              ?.focus()
+          }
+        })
+      },
+      onError: () => toast.error(t("network-error-try-again")),
+    },
+  })
+
+  const label = t("remove-from-favorites", { app: appName })
+
+  return (
+    <Button
+      ref={buttonRef}
+      data-remove-favorite
+      variant="ghost"
+      size="icon"
+      className="text-destructive hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-auto"
+      title={label}
+      aria-label={label}
+      disabled={removeMutation.isPending}
+      onClick={() => removeMutation.mutate({ appId })}
+    >
+      {removeMutation.isPending ? (
+        <Loader2 className="animate-spin" />
+      ) : (
+        <BookmarkMinus />
+      )}
+    </Button>
+  )
 }
 
 const FavoriteApps = ({ locale }: { locale: string }) => {
@@ -34,6 +111,8 @@ const FavoriteApps = ({ locale }: { locale: string }) => {
       return data
     },
     enabled: !!favoritesQuery.data && appIds.length > 0,
+    placeholderData: (previousData) =>
+      previousData?.filter((app) => appIds.includes(app.id)),
   })
 
   if (appdetailQuery.isLoading || favoritesQuery.isLoading) {
@@ -59,6 +138,13 @@ const FavoriteApps = ({ locale }: { locale: string }) => {
         title={t("favorite-apps")}
         applications={appdetailQuery.data}
         variant="nested"
+        renderItemAction={(app) => (
+          <RemoveFavoriteButton
+            appId={app.id}
+            appName={app.name}
+            onRemoved={() => favoritesQuery.refetch()}
+          />
+        )}
       />
       <div>
         <h3 className="mb-3 text-xl font-semibold">
@@ -83,7 +169,13 @@ const MyFlathubClient = ({ locale }: MyFlathubClientProps): JSX.Element => {
       <div className="space-y-12">
         <Breadcrumbs pages={pages} />
         <div className="mt-4 p-4 flex flex-wrap gap-3 rounded-xl bg-flathub-white shadow-md dark:bg-flathub-arsenic">
-          <h1 className="text-4xl font-extrabold">{t("my-flathub")}</h1>
+          <h1
+            data-my-flathub-heading
+            tabIndex={-1}
+            className="text-4xl font-extrabold"
+          >
+            {t("my-flathub")}
+          </h1>
           <div className="space-y-12 w-full">
             {!IS_PRODUCTION && (
               <>

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -392,6 +392,7 @@
   "open-user-menu": "Open User Menu",
   "favorite": "Bookmark",
   "favorite-apps": "Bookmarks",
+  "remove-from-favorites": "Remove {app} from bookmarks",
   "install-all-favorites": "Install All Bookmarks",
   "install-all-favorites-description": "Copy this command to install all your bookmarked apps at once:",
   "no-favorites-yet": "You don't have any bookmarked apps yet. Start adding some by clicking the bookmark icon on apps you like!",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -392,6 +392,7 @@
   "open-user-menu": "Open User Menu",
   "favorite": "Bookmark",
   "favorite-apps": "Bookmarks",
+  "remove-bookmark": "Remove bookmark",
   "remove-from-favorites": "Remove {app} from bookmarks",
   "install-all-favorites": "Install All Bookmarks",
   "install-all-favorites-description": "Copy this command to install all your bookmarked apps at once:",

--- a/frontend/src/components/application/Collection.stories.tsx
+++ b/frontend/src/components/application/Collection.stories.tsx
@@ -63,11 +63,12 @@ export const WithItemActions = () => {
       renderItemAction={(app) => (
         <Button
           variant="ghost"
-          size="icon"
+          size="sm"
           className="text-flathub-sonic-silver hover:bg-destructive/10 hover:text-destructive active:bg-destructive/15 active:text-destructive focus-visible:text-destructive dark:text-flathub-spanish-gray dark:hover:text-destructive"
           aria-label={`Remove ${app.name} from bookmarks`}
         >
           <BookmarkMinus className="size-4" />
+          Remove bookmark
         </Button>
       )}
     />

--- a/frontend/src/components/application/Collection.stories.tsx
+++ b/frontend/src/components/application/Collection.stories.tsx
@@ -64,10 +64,10 @@ export const WithItemActions = () => {
         <Button
           variant="ghost"
           size="icon"
-          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          className="text-flathub-sonic-silver hover:bg-destructive/10 hover:text-destructive active:bg-destructive/15 active:text-destructive focus-visible:text-destructive dark:text-flathub-spanish-gray dark:hover:text-destructive"
           aria-label={`Remove ${app.name} from bookmarks`}
         >
-          <BookmarkMinus />
+          <BookmarkMinus className="size-4" />
         </Button>
       )}
     />

--- a/frontend/src/components/application/Collection.stories.tsx
+++ b/frontend/src/components/application/Collection.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta } from "@storybook/nextjs-vite"
 import Collection from "./Collection"
 import { faker } from "@faker-js/faker"
+import { BookmarkMinus } from "lucide-react"
+import { Button } from "@/components/ui/button"
 
 export default {
   title: "Components/Application/Collection",
@@ -36,5 +38,38 @@ export const WithEolApps = () => {
 
   return (
     <Collection applications={myApps} title={"Apps with EOL"} showEolBadge />
+  )
+}
+
+export const WithItemActions = () => {
+  const myApps = [
+    {
+      id: "tv.kodi.Kodi",
+      icon: "https://dl.flathub.org/media/tv/kodi/Kodi/4f8cbfae09dc6c8c55501a5d3f604fbb/icons/128x128/tv.kodi.Kodi.png",
+      name: "Kodi",
+      summary: "An available app with full AppStream metadata.",
+    },
+    {
+      id: "org.example.Unavailable",
+      name: "org.example.Unavailable",
+    },
+  ]
+
+  return (
+    <Collection
+      applications={myApps}
+      title="Bookmarks"
+      variant="nested"
+      renderItemAction={(app) => (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          aria-label={`Remove ${app.name} from bookmarks`}
+        >
+          <BookmarkMinus />
+        </Button>
+      )}
+    />
   )
 }

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -136,15 +136,13 @@ const ApplicationCollection: FunctionComponent<Props> = ({
                 showId={showId}
                 showRuntime={showRuntime}
                 priority={index < 6}
-                className={itemAction ? "pe-16" : undefined}
+                className={itemAction ? "pe-12" : undefined}
                 endAdornment={
                   showEolBadge && app.is_eol ? <EolBadge /> : undefined
                 }
               />
               {itemAction && (
-                <div className="absolute end-3 top-1/2 z-10 -translate-y-1/2">
-                  {itemAction}
-                </div>
+                <div className="absolute end-2 top-2 z-10">{itemAction}</div>
               )}
             </div>
           )

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, type JSX } from "react"
+import { FunctionComponent, type JSX, type ReactNode } from "react"
 
 import { AppstreamListItem } from "../../types/Appstream"
 
@@ -23,6 +23,9 @@ interface Props {
   showRuntime?: boolean
   showEolBadge?: boolean
   customButtons?: JSX.Element
+  renderItemAction?: (
+    application: GetAppstreamAppstreamAppIdGet200 | AppstreamListItem,
+  ) => ReactNode
 }
 
 const Header = ({
@@ -73,6 +76,7 @@ const ApplicationCollection: FunctionComponent<Props> = ({
   showRuntime = false,
   showEolBadge = false,
   customButtons,
+  renderItemAction,
 }) => {
   const t = useTranslations()
   const searchParams = useSearchParams()
@@ -120,21 +124,31 @@ const ApplicationCollection: FunctionComponent<Props> = ({
       />
 
       <div className="grid grid-cols-1 justify-around gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-3">
-        {applications.map((app, index) => (
-          <div key={app.id} className="flex flex-col gap-2">
-            <ApplicationCard
-              application={app}
-              link={link}
-              variant={variant}
-              showId={showId}
-              showRuntime={showRuntime}
-              priority={index < 6}
-              endAdornment={
-                showEolBadge && app.is_eol ? <EolBadge /> : undefined
-              }
-            />
-          </div>
-        ))}
+        {applications.map((app, index) => {
+          const itemAction = renderItemAction?.(app)
+
+          return (
+            <div key={app.id} className="relative flex flex-col gap-2">
+              <ApplicationCard
+                application={app}
+                link={link}
+                variant={variant}
+                showId={showId}
+                showRuntime={showRuntime}
+                priority={index < 6}
+                className={itemAction ? "pe-16" : undefined}
+                endAdornment={
+                  showEolBadge && app.is_eol ? <EolBadge /> : undefined
+                }
+              />
+              {itemAction && (
+                <div className="absolute end-3 top-1/2 z-10 -translate-y-1/2">
+                  {itemAction}
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {totalPages && <Pagination pages={pages} currentPage={page ?? 1} />}

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -128,7 +128,7 @@ const ApplicationCollection: FunctionComponent<Props> = ({
           const itemAction = renderItemAction?.(app)
 
           return (
-            <div key={app.id} className="relative flex flex-col gap-2">
+            <div key={app.id} className="flex flex-col gap-1">
               <ApplicationCard
                 application={app}
                 link={link}
@@ -136,13 +136,12 @@ const ApplicationCollection: FunctionComponent<Props> = ({
                 showId={showId}
                 showRuntime={showRuntime}
                 priority={index < 6}
-                className={itemAction ? "pe-12" : undefined}
                 endAdornment={
                   showEolBadge && app.is_eol ? <EolBadge /> : undefined
                 }
               />
               {itemAction && (
-                <div className="absolute end-2 top-2 z-10">{itemAction}</div>
+                <div className="flex justify-end px-1">{itemAction}</div>
               )}
             </div>
           )


### PR DESCRIPTION
Add a reusable trailing action slot to app collections and use it on My Flathub so every bookmark can be removed, including fallback cards for unavailable apps. Preserve focus and the remaining grid while removal refreshes.

Fixes #7017